### PR TITLE
Rename image update storage service

### DIFF
--- a/newscoop/classes/Image.php
+++ b/newscoop/classes/Image.php
@@ -86,7 +86,7 @@ class Image extends DatabaseObject
 			camp_load_translation_strings("api");
 		}
 
-        $imageStorageService = Zend_Registry::get('container')->getService('image.update-storage');
+        $imageStorageService = Zend_Registry::get('container')->getService('image.update_storage');
         if ($imageStorageService->isDeletable($this->getImageFileName())) {
             // Deleting the images from disk is the most common place for
             // something to go wrong, so we do that first.

--- a/newscoop/library/Newscoop/Tools/Console/Command/UpdateImageStorageCommand.php
+++ b/newscoop/library/Newscoop/Tools/Console/Command/UpdateImageStorageCommand.php
@@ -32,6 +32,6 @@ class UpdateImageStorageCommand extends Console\Command\Command
      */
     protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output)
     {
-        $this->getHelper('container')->getService('image.update-storage')->updateStorage();
+        $this->getHelper('container')->getService('image.update_storage')->updateStorage();
     }
 }


### PR DESCRIPTION
Media archive is broken because of this. Fix just renames the references to the services from image.update-storage service to image.update_storage
