### PR TITLE
CS-4482: strict error reporting in MAMP

### DIFF
--- a/newscoop/application.php
+++ b/newscoop/application.php
@@ -1,5 +1,7 @@
 <?php
 
+error_reporting(error_reporting() & ~E_STRICT & ~E_DEPRECATED);
+
 // Define path to application directory
 defined('APPLICATION_PATH')
     || define('APPLICATION_PATH', __DIR__ . '/application');


### PR DESCRIPTION
Set error reporting to ~E_STRICT & ~E_DEPRECATED.
