### PR TITLE
fix composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,8 +53,7 @@
             "vendor/Smarty3/libs", 
             "newscoop/classes",
             "newscoop/template_engine",
-            "newscoop/plugins",
-            "plugins"
+            "newscoop/plugins"
         ]
     },
     "include-path": [


### PR DESCRIPTION
don't include code from plugins into classmaps, there is a problem with autoloading after using plugins

there was somewhere ticket for that from Andrey, before i wasn't able to reproduce this, but it happens to me now.
