### PR TITLE
CS-4518: Invalid parameters given to ContextBox::GetList()

### DIFF
--- a/newscoop/classes/ContextBox.php
+++ b/newscoop/classes/ContextBox.php
@@ -59,7 +59,7 @@ Class ContextBox extends DatabaseObject
 
     public function getArticlesList()
     {
-        return ContextBoxArticle::GetList($this->getId(), null, 0, 0, $p_count, FALSE);
+        return ContextBoxArticle::GetList(array('context_box' => $this->getId()), null, 0, 0, $p_count, FALSE);
     }
 
 


### PR DESCRIPTION
Modifies the function call to pass an array as expected.
