### PR TITLE
[4.2] check for key in array before usage

### DIFF
--- a/newscoop/admin-files/localizer/Localizer.php
+++ b/newscoop/admin-files/localizer/Localizer.php
@@ -747,7 +747,7 @@ class Localizer {
         $untranslated = 0;
 
         foreach ($sourceStrings as $k => $v) {
-            if (strlen($targetStrings[$k])) {
+            if (array_key_exists($k, $targetStrings) && strlen($targetStrings[$k])) {
                 $translated++;
             } else {
                 $untranslated++;


### PR DESCRIPTION
Fix for:
`Fatal error: Uncaught exception 'Newscoop\Utils\Exception' with message 'Undefined index: Ban for commenter "$1" saved.' in /var/www/miedzyrzecsiedzieje.dev/newscoop/admin-files/localizer/Localizer.php:750`
