### PR TITLE
[4.2] Allow for setting in configuration default publication id for publisher

### DIFF
--- a/newscoop/library/Newscoop/Services/Ingest/PublisherService.php
+++ b/newscoop/library/Newscoop/Services/Ingest/PublisherService.php
@@ -112,6 +112,10 @@ class PublisherService
      */
     public function getPublication()
     {
+        if (array_key_exists('default_publication_id', $this->config)) {
+            return (int) $this->config['default_publication_id'];
+        }
+        
         $publications = $GLOBALS['Campsite']['publications'];
         if (empty($publications)) {
             throw new \RuntimeException("No publications defined.");
@@ -138,27 +142,8 @@ class PublisherService
      */
     public function getSection(Entry $entry)
     {
-        switch ($entry->getSubject()) {
-            case '15000000':
-                return $this->config['section_sport'];
-                break;
-
-            case '1000000':
-                return $this->config['section_culture'];
-                break;
-        }
-
-        //has to be before country checking.
-        if ($entry->getProduct() == "swissinfo") {
-            return $this->config['section_swiss_info'];
-        }
-
-        if ($entry->getCountry() != 'CH')  {
-            return $this->config['section_international'];
-        }
-
-        if ($entry->getProduct() == "Regionaldienst Nord") {
-            return $this->config['section_basel'];
+        if (array_key_exists($entry->getSubject(), $this->config)) {
+            return $this->config[$entry->getSubject()];
         }
 
         return $this->config['section_other'];


### PR DESCRIPTION
If instance have more than one publication then we can set default publication id for publisher in config: ex.

```
ingest_publisher.default_publication_id = 2
```
