### PR TITLE
CS-4538: Deletion of articles breaks when Solr search is not setup

### DIFF
--- a/newscoop/application/configs/application.ini-dist
+++ b/newscoop/application/configs/application.ini-dist
@@ -91,7 +91,7 @@ listener[] = community_feed
 listener[] = user_points
 listener[] = user_attributes
 listener[] = comment_notification
-listener[] = search.indexer.article
+;listener[] = search.indexer.article
 
 ; audit events
 audit.events[] = comment.update


### PR DESCRIPTION
Remove article indexer listener from default setup.
