### PR TITLE
CS-4549: Allow users to override Solr server url

### DIFF
--- a/newscoop/application/Bootstrap.php
+++ b/newscoop/application/Bootstrap.php
@@ -208,7 +208,7 @@ class Bootstrap extends Zend_Application_Bootstrap_Bootstrap
 
         $container->register('search.index', 'Newscoop\Search\SolrIndex')
             ->addArgument(new sfServiceReference('http.client.factory'))
-            ->addArgument('%config%');
+            ->addArgument('%search%');
 
         $container->register('search.indexer.article', 'Newscoop\Search\ArticleIndexer')
             ->addArgument(new sfServiceReference('em'))

--- a/newscoop/application/configs/application.ini-dist
+++ b/newscoop/application/configs/application.ini-dist
@@ -237,6 +237,8 @@ blog.article_type = "blog"
 image.cache_url = "images/cache"
 image.cache_path = APPLICATION_PATH "/../images/cache"
 
+search.solr_server = 'http://localhost:8983/solr'
+
 [staging : production]
 
 [testing : production]


### PR DESCRIPTION
Changes config setting from solr_server to search.solr_server
Adds search.solr_server to application.ini-dist

Users may override default value by adding:

search.solr_server = '<url>'

to production and cli environments in application.ini
