### PR TITLE
MOTM-439: Allow bloggers to remove autopublish events

### DIFF
--- a/newscoop/library/Newscoop/Services/BlogService.php
+++ b/newscoop/library/Newscoop/Services/BlogService.php
@@ -30,6 +30,7 @@ class BlogService
         'comments',
         'autopublish.php',
         'do_unlock.php',
+        'autopublish_del.php',
     );
 
     /** @var array */


### PR DESCRIPTION
Add autopublish remove to blogger service action whitelist.
