### PR TITLE
MOTM-504: Subscribing to topic newsletters not working correctly

### DIFF
--- a/newscoop/library/Newscoop/MailChimp/ListApi.php
+++ b/newscoop/library/Newscoop/MailChimp/ListApi.php
@@ -107,8 +107,18 @@ class ListApi
         } else {
             unset($values['subscriber']);
         }
-
+        
         $groupings = array();
+
+        /**
+         * Zentral+ custom code to allow
+         * unsubscribe to all Themen list topics
+         */
+        $groupings[] = array(
+            'name' => 'Themen',
+            'groups' => '',
+        );
+
         foreach ($values as $name => $groups) {
             if (empty($groups)) {
                 continue;


### PR DESCRIPTION
added custom code in ListApi because I had trouble with zend form validator.  the better fix would be to add
a hidden form field for the Themen array with a value of "" that gets posted to the form and forces the Themen groups
list to be overwritten
