### PR TITLE
Update newscoop/admin-files/articles/edit_playlist.php

### DIFF
--- a/newscoop/admin-files/articles/edit_playlist.php
+++ b/newscoop/admin-files/articles/edit_playlist.php
@@ -21,15 +21,15 @@
           }
       ?>
 
+      <ul class="block-list" id="added-to-playlists">
       <?php if ($playlistsData) : ?>
-        <ul class="block-list" id="added-to-playlists">
         <?php foreach ($playlistsData as $playlist) : ?>
           <li playlist-id="<?php echo $playlist->id ?>">
             <?php echo $this->view->escape($playlist->name); ?>
           </li>
         <?php endforeach; ?>
-        </ul>
       <?php endif; ?>
+      </ul>
       </div>
 
       <?php if ($inEditMode && $GLOBALS['controller']->getHelper('acl')->isAllowed('playlist', 'manage')) : ?>


### PR DESCRIPTION
Fix bug with not showing article playlist after first add.

UL element was creating only when at least one article playlist exists, and js was broken when that element was missing.
