### PR TITLE
IM-589 - clear data about comment from request

### DIFF
--- a/newscoop/template_engine/metaclasses/MetaActionSubmit_Comment.php
+++ b/newscoop/template_engine/metaclasses/MetaActionSubmit_Comment.php
@@ -204,7 +204,6 @@ class MetaActionSubmit_Comment extends MetaAction
         if($p_context->comment->identifier)
             $values['parent'] = $p_context->comment->identifier;
 
-
         $commentObj = $repository->getPrototype();
         $comment = $repository->save($commentObj,$values);
         $repository->flush();


### PR DESCRIPTION
Clear data about comment from request.
f_submit_comment in request calls MetaAction_Submit_Comment and try save comment again. 
