### PR TITLE
Add language specific search route.

### DIFF
--- a/newscoop/application/controllers/SearchController.php
+++ b/newscoop/application/controllers/SearchController.php
@@ -11,5 +11,9 @@ class SearchController extends Zend_Controller_Action
 {
     public function indexAction()
     {
+        if ($this->_getParam('language')) {
+            $gimme = CampTemplate::singleton()->context();
+            $gimme->language = MetaLanguage::createFromCode($this->_getParam('language'));
+        }
     }
 }

--- a/newscoop/application/views/scripts/search_index.tpl
+++ b/newscoop/application/views/scripts/search_index.tpl
@@ -3,7 +3,7 @@
 {{block content}}
 <h1>Search results</h1>
 
-{{ list_search_results_solr qf="title^5 deck^3 full_text" start=$smarty.get.start  }}
+{{ list_search_results_solr qf="title^5 deck^3 full_text" start=$smarty.get.start|default:0  }}
   {{ if $gimme->current_list->at_beginning }}
   <ul>
   {{ /if }}

--- a/newscoop/include/smarty/campsite_plugins/block.form_search_solr.php
+++ b/newscoop/include/smarty/campsite_plugins/block.form_search_solr.php
@@ -17,10 +17,16 @@ function smarty_block_form_search_solr($params, $content, $smarty)
         return;
     }
 
+    $language = null;
+    $gimme = $smarty->getTemplateVars('gimme');
+    if ($gimme->language->code !== $gimme->publication->default_language->code) {
+        $language = $gimme->language->code;
+    }
+
     $view = $smarty->getTemplateVars('view');
     $params += array(
         'method' => 'GET',
-        'action' => $view->url(array('controller' => 'search', 'action' => 'index'), 'default'),
+        'action' => $view->url(array('language' => $language), 'search'),
     );
 
     return $view->form('search_articles', $params, $content);

--- a/newscoop/library/Newscoop/Router/RouterFactory.php
+++ b/newscoop/library/Newscoop/Router/RouterFactory.php
@@ -105,6 +105,19 @@ class RouterFactory
             ))
         );
 
+        $router->addRoute(
+            'search',
+            new Zend_Controller_Router_Route(
+                ':language/search',
+                array(
+                    'module' => 'default',
+                    'controller' => 'search',
+                    'action' => 'index',
+                    'language' => null,
+                )
+            )
+        );
+
         return $router;
     }
 }

--- a/newscoop/template_engine/metaclasses/MetaLanguage.php
+++ b/newscoop/template_engine/metaclasses/MetaLanguage.php
@@ -67,6 +67,9 @@ final class MetaLanguage extends MetaDbObject {
 	$this->m_customProperties['defined'] = 'defined';
     } // fn __construct
 
-} // class MetaLanguage
-
-?>
+    public static function createFromCode($code)
+    {
+        $languageId = Language::GetLanguageIdByCode($code);
+        return new self($languageId);
+    }
+}


### PR DESCRIPTION
When searching with solr we need to pick right language. Currently there was no support for different search endpoints e.g. /en/search, /es/search. This pr adds language as route param and sets environment according to it.
