### PR TITLE
Fixes CS-4699

### DIFF
--- a/newscoop/application/console
+++ b/newscoop/application/console
@@ -1,4 +1,3 @@
-#!/usr/bin/env php
 <?php
 global $g_ado_db;
 


### PR DESCRIPTION
Removes the /usr/bin/env php from the Console file. This caused a Session error oddly enough.
