### PR TITLE
MOTM-730: Added installation script with fixture for Infosperber feed

### DIFF
--- a/newscoop/install/sql/upgrade/4.1.x/2013-10-07/data-required.sql
+++ b/newscoop/install/sql/upgrade/4.1.x/2013-10-07/data-required.sql
@@ -1,0 +1,4 @@
+
+-- add new ingest to table,
+INSERT INTO `ingest_feed` (`title`, `mode`, `updated`) VALUES ('infosperber', 'auto', NULL);
+


### PR DESCRIPTION
Script will add infosperber to correct table. Without the infosperber feeds will not be updated.
