### PR TITLE
Update index.js

### DIFF
--- a/newscoop/js/app/admin/themes/index.js
+++ b/newscoop/js/app/admin/themes/index.js
@@ -83,7 +83,7 @@ newscoopDatatables =
 			$(this).children("ul").css("display","block");
 		}, function()
 		{
-			$(this).childer("ul").css("display","none");
+			$(this).children("ul").css("display","none");
 		});
 
 		try


### PR DESCRIPTION
There is no jQuery method 'childer'. Changed to the obvious 'children' method instead.
