### PR TITLE
CS-4873: Fixes error thrown when $translator variable is used in GetURI(...

### DIFF
--- a/newscoop/classes/ShortURL.php
+++ b/newscoop/classes/ShortURL.php
@@ -77,9 +77,6 @@ class ShortURL
 		if (!is_null($p_articleNo)) {
 			$articleObj = new Article($p_languageId, $p_articleNo);
 
-			// echo '$p_articleNo: '.$p_articleNo.'<br>';
-			// echo '<pre>$articleObj:'. nl2br(print_r($articleObj, true)).'</pre><hr>'; exit;
-
 			if (!$articleObj->exists()) {
 				return new PEAR_Error($translator->trans('Article does not exist.'));
 			}


### PR DESCRIPTION
...) method.
