### PR TITLE
[CS-4894] Media archive is showing previous description after change des...

### DIFF
--- a/newscoop/admin-files/media-archive/index.php
+++ b/newscoop/admin-files/media-archive/index.php
@@ -307,7 +307,10 @@ function newscoopMediaArchiveDataTable (element) {
         hideOnContentClick: false,
         width: 1300,
         height: 800,
-        type: 'iframe'
+        type: 'iframe',
+        onClosed: function() {
+           location.reload();
+        }
     });
 };
 


### PR DESCRIPTION
...cription.

Media library is reloaded and showing changed datatable values.

Possible improvement:
- update jQuery to latest version
- update fancybox plugin to latest version
- change deprecated fancybox callbacks
