### PR TITLE
local image path revert

### DIFF
--- a/newscoop/library/Newscoop/Image/LocalImage.php
+++ b/newscoop/library/Newscoop/Image/LocalImage.php
@@ -157,9 +157,9 @@ class LocalImage implements ImageInterface
     public function getPath()
     {
         if ($this->hasUpdatedStorage()) {
-            return '/images/' . $this->basename;
+            return 'images/' . $this->basename;
         } elseif ($this->isLocal()) {
-            return basename($this->basename) === $this->basename ? '/images/' . $this->basename : $this->basename;
+            return basename($this->basename) === $this->basename ? 'images/' . $this->basename : $this->basename;
         } else {
             return $this->url;
         }


### PR DESCRIPTION
Related to [CS-4858 ticket: slideshow item object - missing "/" in original url.

Slideshows work without missing slash and with it. I have removed it from LocalImage class because it causes problems in backend when creating new slideshows.
