### PR TITLE
MOTM-957: Only returns parent articles which are dossiers

### DIFF
--- a/newscoop/classes/ContextBoxArticle.php
+++ b/newscoop/classes/ContextBoxArticle.php
@@ -85,8 +85,10 @@ class ContextBoxArticle extends DatabaseObject
         }
 
         if (isset($params['role']) && $params['role'] == 'child') {
-            $sql = 'SELECT b.fk_article_no FROM context_boxes b'
-                . ' WHERE b.id = (SELECT c.fk_context_id '
+            $sql = 'SELECT b.fk_article_no FROM context_boxes b, Articles a0'
+                . ' WHERE a0.Number = b.fk_article_no AND '
+                . ' a0.Type = "dossier" AND '
+                . ' b.id IN (SELECT c.fk_context_id '
                 . '     FROM Articles a, context_articles c '
                 . '     WHERE c.fk_article_no = ' . $params['article']
                 . '     AND a.Number = c.fk_article_no)'


### PR DESCRIPTION
Could return multiple parent articles if the articles was linked as a related article.
In this case only one result was returned and no checking was done.

Conflicts:
    newscoop/classes/ContextBoxArticle.php
