### PR TITLE
[CS-4905] added possibility to change user image resolution

### DIFF
--- a/newscoop/application/controllers/OmniboxController.php
+++ b/newscoop/application/controllers/OmniboxController.php
@@ -40,10 +40,15 @@ class OmniboxController extends Zend_Controller_Action
 
             if ($result->getCode() == Zend_Auth_Result::SUCCESS) {
                 $user = Zend_Registry::get('container')->getService('user')->getCurrentUser();
+                $metaUser = new \MetaUser($user);
+                $width = array_key_exists("imageWidth", $params) ? $params['imageWidth'] : 80;
+                $height = array_key_exists("imageHeight", $params) ? $params['imageHeight'] : 80;
+                $specification = array_key_exists("imageSpecification", $params) ? $params['imageSpecification'] : 'fit';
+
                 $this->view->userData = array(
                     'realName' => $user->getRealName(),
                     'username' => $user->getUsername(),
-                    'avatar' => $user->getImage()
+                    'avatar' => $metaUser->image($width, $height, $specification)
                 );
 
                 $this->view->response = 'OK';


### PR DESCRIPTION
Related to ticket: http://dev.sourcefabric.org/browse/CS-4905

There is added possibility to read user data and read logged in user data using Omnibox.

**Omnibox URL:** http://example.com/omnibox/login/?format=json

**Supported parameters in Ajax call:**
- **imageWidth** - user image width (e.g. 50)
- **imageHeight** - user image height (e.g. 50)
- **imageSpecification** - user image specification ('crop' or 'fit')

if not above parameters defined, default options will apply:
- width: 80
- height: 80
- specification: fit

**User data in response:**
- realName
- username
- avatar

**Example response:**

```
{"helpUrl":"http:\/\/www.sourcefabric.org\/en\/products\/newscoop_support\/","locale":"en","userData":{"realName":"Amerigo Vespucci","username":"amerigo","avatar":"\/images\/cache\/50x50\/crop\/images%7Cdc1989572b1a6a68f1981597d0a79eadd2df98df.jpg"},"response":"OK"}
```
