### PR TITLE
Adds $order variable, would throw error in template

### DIFF
--- a/newscoop/template_engine/classes/ArticleAuthorsList.php
+++ b/newscoop/template_engine/classes/ArticleAuthorsList.php
@@ -68,6 +68,7 @@ class ArticleAuthorsList extends ListObject
 	 */
 	protected function ProcessOrder(array $p_order)
 	{
+        $order = array();
         if (count($p_order) == 1) {
             $p_order[] = 'asc';
         }


### PR DESCRIPTION
Fixes undefined variable error for article author lists in template.
