### PR TITLE
add cacheservice

### DIFF
--- a/newscoop/application/configs/services/services.yml
+++ b/newscoop/application/configs/services/services.yml
@@ -195,6 +195,9 @@ services:
         class: Newscoop\Services\PlaceholdersService
     newscoop.listpaginator.service:
         class: Newscoop\Services\ListPaginatorService
+    newscoop.cache:
+        class: Newscoop\Services\CacheService
+        arguments: ["@system_preferences_service"]
 
     # Add this event listener registering to newscoop/application/configs/parameters/custom_parameters.yml
     # search_indexer:

--- a/newscoop/classes/CampCache.php
+++ b/newscoop/classes/CampCache.php
@@ -11,8 +11,9 @@ define('CACHE_SERIAL_FOOTER', "*/\n?".">");
 
 
  /**
- * @package Campsite
- */
+  * @package Campsite
+  * @deprecated from 4.3, removed in 4.4, use newscoop.cache service
+  */
 final class CampCache
 {
     /**
@@ -55,10 +56,12 @@ final class CampCache
 
     /**
      * CampCache class constructor.
-     *
+     * @deprecated from 4.3, removed in 4.4, use newscoop.cache service
      */
     private function __construct($p_cacheEngine)
     {
+        return;
+
         global $Campsite;
 
         if (empty($p_cacheEngine)) {
@@ -375,12 +378,9 @@ final class CampCache
      */
     public static function IsEnabled($p_cacheEngine = null)
     {
-        if (is_null(self::$m_enabled)) {
-            self::singleton();
-        }
-        return self::$m_enabled;
-    } // fn IsEnabled
-
-} // class CampCache
-
-?>
+        /**
+         * @deprecated from 4.3, removed in 4.4, use newscoop.cache service
+         */
+        return false;
+    }
+}

--- a/newscoop/include/smarty/campsite_plugins/function.listpagination.php
+++ b/newscoop/include/smarty/campsite_plugins/function.listpagination.php
@@ -33,7 +33,7 @@ function smarty_function_listpagination($params, &$smarty)
                 return $templatesService->fetchTemplate($params['file'], array('data' => $data));
             };
         } else {
-             $context->current_list->pagination->renderer = function ($data) use ($templatesService, $params) {
+            $context->current_list->pagination->renderer = function ($data) use ($templatesService, $params) {
                 return $templatesService->fetchTemplate('_pagination/twitter_bootstrap_v2_pagination.tpl', array('data' => $data));
             };
         }

--- a/newscoop/library/Newscoop/Services/CacheService.php
+++ b/newscoop/library/Newscoop/Services/CacheService.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * @package Newscoop
+ * @copyright 2014 Sourcefabric o.p.s.
+ * @author Paweł Mikołąjczuk <pawel.mikolajczuk@sourcefabric.org>
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+namespace Newscoop\Services;
+
+/**
+ * Cache service
+ */
+class CacheService
+{
+    /**
+     * Instance of cache driver
+     *
+     * @var \Doctrine\Common\Cache\CacheProvider
+     */
+    private $cacheDriver;
+
+    /**
+     * Initialize cache driver (based on system preferences settings, default is array)
+     *
+     * @param \Newscoop\NewscoopBundle\Services\SystemPreferencesService $systemPreferences
+     */
+    public function __construct($systemPreferences)
+    {
+        try {
+            switch ($systemPreferences->get('DBCacheEngine', 'array')) {
+                case 'apc':
+                    $this->cacheDriver = new \Doctrine\Common\Cache\ApcCache();
+                    break;
+                case 'memcache':
+                    $memcache = new \Memcache();
+                    $memcache->connect(
+                        $systemPreferences->get('DBCacheEngineHost', '127.0.0.1'), 
+                        $systemPreferences->get('DBCacheEnginePort', '11211')
+                    );
+
+                    $this->cacheDriver = new \Doctrine\Common\Cache\MemcacheCache();
+                    $this->cacheDriver->setMemcache($memcache);
+                    break;
+                case 'memcached':
+                    $memcached = new \Memcached();
+                    $memcached->addServer(
+                        $systemPreferences->get('DBCacheEngineHost', '127.0.0.1'), 
+                        $systemPreferences->get('DBCacheEnginePort', '11211')
+                    );
+
+                    $this->cacheDriver = new \Doctrine\Common\Cache\MemcachedCache();
+                    $this->cacheDriver->setMemcached($memcached);
+                    break;
+                case 'xcache':
+                    $this->cacheDriver = new \Doctrine\Common\Cache\XcacheCache();
+                    break;
+                case 'redis':
+                    $redis = new \Redis();
+                    $redis->connect(
+                        $systemPreferences->get('DBCacheEngineHost', '127.0.0.1'), 
+                        $systemPreferences->get('DBCacheEnginePort', '6379')
+                    );
+                    $this->cacheDriver = new \Doctrine\Common\Cache\RedisCache();
+                    $this->cacheDriver->setRedis($redis);
+                    break;
+                default:
+                    $this->cacheDriver = new \Doctrine\Common\Cache\ArrayCache();
+                    break;
+            }
+        } catch (\Exception $e) {
+            $this->cacheDriver = new \Doctrine\Common\Cache\ArrayCache();
+        }
+    }
+
+    /**
+     * Fetch data from cache
+     *
+     * @param string|array $id
+     *
+     * @return mixed
+     */
+    public function fetch($id)
+    {
+        if (is_array($id)) {
+            $id = implode('__', $id);
+        }
+
+        return $this->cacheDriver->fetch($id);
+    }
+
+    /**
+     * Check if cache have provided key
+     *
+     * @param string|array $id
+     *
+     * @return boolean
+     */
+    public function contains($id)
+    {
+        if (is_array($id)) {
+            $id = implode('__', $id);
+        }
+
+        return $this->cacheDriver->contains($id);
+    }
+
+    /**
+     * Save new value in cache
+     *
+     * @param string|array $id
+     * @param mixed        $data
+     * @param integer      $lifeTime
+     *
+     * @return boolean
+     */
+    public function save($id, $data, $lifeTime = 1400)
+    {
+        if (is_array($id)) {
+            $id = implode('__', $id);
+        }
+
+        return $this->cacheDriver->save($id, $data, $lifeTime);
+    }
+
+    /**
+     * Delete key from cache
+     *
+     * @param string|array $id
+     *
+     * @return boolean
+     */
+    public function delete($id)
+    {
+        if (is_array($id)) {
+            $id = implode('__', $id);
+        }
+
+        return $this->cacheDriver->delete($id);
+    }
+
+    /**
+     * Get array of avaiable cache drivers (based on system configurations)
+     *
+     * @return array
+     */
+    public function getAvailableCacheEngines()
+    {
+        $engines = array();
+
+        if (extension_loaded('apc') && ini_get('apc.enabled')) {
+            $engines['Apc'] = 'apc';
+        }
+
+        if (class_exists('\Redis')) {
+            $engines['Redis'] = 'redis';
+        }
+
+        if (class_exists('\Memcache')) {
+            $engines['Memcache'] = 'memcache';
+        }
+
+        if (class_exists('\Memcached')) {
+            $engines['Memcached'] = 'memcached';
+        }
+
+        if (extension_loaded('xcache') && ini_get('xcache.cacher')) {
+            $engines['Xcache'] = 'xcache';
+        }
+
+        return $engines;
+    }
+
+    /**
+     * Get cache driver instance
+     *
+     * @return \Doctrine\Common\Cache\CacheProvider
+     */
+    public function getCacheDriver()
+    {
+        return $this->cacheDriver;
+    }
+}

--- a/newscoop/src/Newscoop/NewscoopBundle/Form/Type/PreferencesType.php
+++ b/newscoop/src/Newscoop/NewscoopBundle/Form/Type/PreferencesType.php
@@ -55,12 +55,12 @@ class PreferencesType extends AbstractType
             }
         }
 
-        $availableCacheEngines = \CacheEngine::AvailableEngines();
+        $availableCacheEngines = $options['cacheService']->getAvailableCacheEngines();
         $availableTemplateCacheHandlers = \CampTemplateCache::availableHandlers();
         $cacheEngines = array();
         $cacheTemplate = array();
-        foreach ($availableCacheEngines as $cacheEngineName => $engineData) {
-            $cacheEngines[$cacheEngineName] = $cacheEngineName;
+        foreach ($availableCacheEngines as $cacheEngineName => $engineValue) {
+            $cacheEngines[$engineValue] = $cacheEngineName;
         }
 
         foreach ($availableTemplateCacheHandlers as $handler => $value) {
@@ -135,7 +135,15 @@ class PreferencesType extends AbstractType
         ))
         ->add('cache_engine', 'choice', array(
             'choices'   => $cacheEngines,
-            'empty_value' => 'newscoop.preferences.label.disabled',
+            'empty_value' => 'Array',
+            'required' => false
+        ))
+        ->add('cache_engine_host', 'text', array(
+            'error_bubbling' => true,
+            'required' => false
+        ))
+        ->add('cache_engine_port', 'text', array(
+            'error_bubbling' => true,
             'required' => false
         ))
         ->add('cache_template', 'choice', array(
@@ -428,6 +436,11 @@ class PreferencesType extends AbstractType
         $resolver->setDefaults(array(
             'translation_domain' => 'system_pref'
         ));
+
+        $resolver->setRequired(array(
+            'cacheService',
+        ));
+
 
     }
 

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/system_pref.en.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/system_pref.en.yml
@@ -10,8 +10,10 @@ newscoop:
       noaccess: "You do not have the right to change system preferences."
       latitude: "Latitude field value is not valid."
       longitude: "Longitude field value is not valid."
+      cacheNotCleared: "There was error with cache clearing"
     success:
       saved: "System preferences updated."
+      cacheCleared: "Cache was cleared"
     menu:
       general: "General Settings"
       email: "Email Settings"
@@ -22,6 +24,8 @@ newscoop:
       cache: "Cache Settings"
       other: "Other Settings"
       recaptcha: "reCAPTCHA Settings"
+    btn:
+      cleardatabasecache: "Clear current driver cache"
     label:
       title: "System Preferences"
       header: "Preferences"
@@ -31,6 +35,8 @@ newscoop:
       metadescription: "Site Meta Description:"
       timezone: "Time Zone:"
       cacheengine: "Database Cache Engine:"
+      cacheenginehost: "Database Cache Engine Host:"
+      cacheengineport: "Database Cache Engine Port:"
       cachetemplate: "Template Cache Handler:"
       cacheimage: "Imagecache Lifetime:"
       allowrecovery: "Allow password recovery:"
@@ -99,7 +105,9 @@ newscoop:
       nooption: "No"
       geosearch: "Use Local GeoNames Search:"
     popover:
-      cacheengine: "Enables or disables the APC cache, which can improve Newscoop performance."
+      cacheengine: "Enables or disables system cache cache, which can improve Newscoop performance."
+      cacheenginehost: "Provide cache host (for Memcache, Memcached or Redis)"
+      cacheengineport: "Provide cache host port (for Memcache, Memcached or Redis)"
       cacheimage: "The time that images will be cached for, from 30 seconds to infinite."
       cachetemplate: "Select DB to enable the cache for templates."
       recovery: "Whether users can get a password reminder by email. Note that if this feature is enabled and your email account is compromised, your Newscoop publication can easily be compromised in turn."

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/views/SystemPref/index.html.twig
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/views/SystemPref/index.html.twig
@@ -144,6 +144,23 @@
                         {{ form_widget(form.cache_engine, {'attr' : {'class' : 'input_select wide'}}) }} 
                     </dd>
                     <dt>
+                        <label>{{ 'newscoop.preferences.label.cacheenginehost'|trans }} <small id="cacheenginehost">(?)</small></label>
+                    </dt>
+                    <dd>
+                        {{ form_widget(form.cache_engine_host, {'attr' : {'class' : 'input_text wide'}}) }} 
+                    </dd>
+                    <dt>
+                        <label>{{ 'newscoop.preferences.label.cacheengineport'|trans }} <small id="cacheengineport">(?)</small></label>
+                    </dt>
+                    <dd>
+                        {{ form_widget(form.cache_engine_port, {'attr' : {'class' : 'input_text','style' : 'width: 81px;'}}) }} 
+                    </dd>
+
+                    <div class="clear-database-cache">
+                        <button class="btn btn-small btn-danger" type="text">{{ 'newscoop.preferences.btn.cleardatabasecache'|trans }}</button>
+                    </div>
+
+                    <dt>
                         <label>{{ 'newscoop.preferences.label.cachetemplate'|trans }} <small id="cachetemplate">(?)</small></label>
                     </dt>
                     <dd>
@@ -511,7 +528,27 @@
         $("input:radio[name=preferencesform\\[use_replication\\]]:checked").change();
     });
 
+    $('.clear-database-cache button').click(function(e){
+        e.preventDefault();
+
+        var that = $(this);
+        callServer('ping', [], function(json) {
+            $.ajax({
+                type: 'POST',
+                url: Routing.generate('newscoop_newscoop_systempref_cleardatabasecache'),
+                success: function (data) {
+                    flashMessage('{{ 'newscoop.preferences.success.cacheCleared'|trans}}');
+                },
+                error: function (rq, status, error) {
+                    flashMessage('{{ 'newscoop.preferences.error.cacheNotCleared'|trans}}', "error");
+                }
+            });
+        });
+    });
+
     popover($('#cacheengine'), '{{ 'newscoop.preferences.popover.cacheengine'|trans }}');
+    popover($('#cacheenginehost'), '{{ 'newscoop.preferences.popover.cacheenginehost'|trans }}');
+    popover($('#cacheengineport'), '{{ 'newscoop.preferences.popover.cacheengineport'|trans }}');
     popover($('#cachetemplate'), '{{ 'newscoop.preferences.popover.cachetemplate'|trans }}');
     popover($('#cacheimage'), '{{ 'newscoop.preferences.popover.cacheimage'|trans }}');
     popover($('#allowrecovery'), '{{ 'newscoop.preferences.popover.recovery'|trans }}');

--- a/newscoop/src/Newscoop/NewscoopBundle/Services/SystemPreferencesService.php
+++ b/newscoop/src/Newscoop/NewscoopBundle/Services/SystemPreferencesService.php
@@ -84,7 +84,7 @@ class SystemPreferencesService
      * @return string|null
      */
     public function __get($property)
-    {   
+    {
         $currentProperty = $this->findOneBy($property);
 
         if (!$currentProperty->isEmpty()) {
@@ -96,9 +96,9 @@ class SystemPreferencesService
 
     /**
      * Set given value for given property
-     * 
-     * @param  $property Given property
-     * @param  $value    Value for given property
+     *
+     * @param $property Given property
+     * @param $value    Value for given property
      *
      * @return void
      */
@@ -110,13 +110,19 @@ class SystemPreferencesService
     /**
      * Get value for given property
      *
-     * @param  $property Given property
+     * @param $property Given property
      *
      * @return string
      */
-    public function get($property)
+    public function get($property, $default = null)
     {
-        return $this->$property;
+        $property = $this->$property;
+
+        if ($property === null) {
+            return $default;
+        }
+
+        return $property;
     }
 
     /**
@@ -125,7 +131,7 @@ class SystemPreferencesService
      * @return array
      */
     public function getAllPreferences()
-    {   
+    {
         if ($this->preferences) {
             return $this->preferences;
         }
@@ -137,7 +143,7 @@ class SystemPreferencesService
      * Find one preference by matching criteria from object
      * Works like caching
      *
-     * @param  string $property Property name
+     * @param string $property Property name
      *
      * @return ArrayCollection
      */
@@ -148,7 +154,7 @@ class SystemPreferencesService
         $criteria = new Criteria($expr);
 
         $preferences = new ArrayCollection($this->getAllPreferences());
-        
+
         return $preferences->matching($criteria);
     }
 }


### PR DESCRIPTION
Database cache service based on Doctrine2 caching (http://doctrine-orm.readthedocs.org/en/latest/reference/caching.html). 

User can choose cache driver, by default array cache is initialized. Must use with big database queries. 

```
$cacheService  = $this->container->get('newscoop.cache');
```
