### PR TITLE
CS-4994: Adds switch to user profile

### DIFF
--- a/newscoop/application/modules/admin/controllers/UserController.php
+++ b/newscoop/application/modules/admin/controllers/UserController.php
@@ -210,7 +210,13 @@ class Admin_UserController extends Zend_Controller_Action
         $request = $this->getRequest();
         if ($request->isPost() && $form->isValid($request->getPost())) {
             try {
-                $this->userService->save($form->getValues(), $user);
+                $values = $form->getValues();
+                $values['attributes'] = array(
+                    'is_verified' => $values['is_verified'],
+                );
+                unset($values['is_verified']);
+
+                $this->userService->save($values, $user);
                 $this->_helper->flashMessenger($translator->trans("User saved", array(), 'users'));
                 $this->_helper->redirector('edit', 'user', 'admin', array(
                     'user' => $user->getId(),

--- a/newscoop/application/modules/admin/forms/User.php
+++ b/newscoop/application/modules/admin/forms/User.php
@@ -77,6 +77,10 @@ class Admin_Form_User extends Zend_Form
             'label' => $translator->trans("Allow users profile to be publicly displayed", array(), 'users'),
         ));
 
+        $this->addElement('checkbox', 'is_verified', array(
+            'label' => $translator->trans('User account is verified', array(), 'users'),
+        ));
+
         $this->addElement('multiCheckbox', 'user_type', array(
             'label' => $translator->trans('User Type', array(), 'users'),
         ));
@@ -119,6 +123,7 @@ class Admin_Form_User extends Zend_Form
             'status' => $user->isActive(),
             'is_admin' => $user->isAdmin(),
             'is_public' => $user->isPublic(),
+            'is_verified' => $user->getAttribute('is_verified'),
             'user_type' => $types,
             'author' => $user->getAuthorId(),
         ));

--- a/newscoop/library/Newscoop/Entity/Repository/UserRepository.php
+++ b/newscoop/library/Newscoop/Entity/Repository/UserRepository.php
@@ -262,6 +262,20 @@ class UserRepository extends EntityRepository implements RepositoryInterface
         return $users;
     }
 
+    public function findVerifiedUsers($countOnly, $offset, $limit)
+    {
+        if ($countOnly) {
+            $qb = $this->getEntityManager()->createQuery('SELECT COUNT(u.id) FROM Newscoop\Entity\User u JOIN u.attributes a WHERE a.attribute = \'is_verified\' AND a.value = 1');
+            return $qb->getSingleScalarResult();
+        }
+
+        $qb = $this->getEntityManager()->createQuery('SELECT u FROM Newscoop\Entity\User u JOIN u.attributes a WHERE a.attribute = \'is_verified\' AND a.value = 1');
+        $qb->setFirstResult($offset);
+        $qb->setMaxResults($limit);
+
+        return $qb->getResult();
+    }
+
     /**
      * Create query builder for public users
      *


### PR DESCRIPTION
Compared all core with TW this is all we need. Other references to is_verified are already in Newscoop or templates.
