### PR TITLE
Upgraded vagrant file to support 1.1+ Vagrant syntax

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-Vagrant::Config.run do |config|
+VAGRANTFILE_API_VERSION = "2"
+Vagrant.configure( VAGRANTFILE_API_VERSION ) do |config|
   # All Vagrant configuration is done here. The most common configuration
   # options are documented and commented below. For a complete reference,
   # please see the online documentation at vagrantup.com.
@@ -29,12 +30,9 @@ Vagrant::Config.run do |config|
 
   # Forward a port from the guest to the host, which allows for outside
   # computers to access the VM, whereas host only networking does not.
-  config.vm.forward_port 80, 8080
+  config.vm.network "forwarded_port", guest:80, host:8080
 
-  # Share an additional folder to the guest VM. The first argument is
-  # an identifier, the second is the path on the guest to mount the
-  # folder, and the third is the path on the host to the actual folder.
-  config.vm.share_folder "v-root", "/vagrant", "./", {:extra => 'dmode=777,fmode=777'}
+  config.vm.synced_folder "./", "/vagrant"
 
   # Enable provisioning with Puppet stand alone.  Puppet manifests
   # are contained in a directory path relative to this Vagrantfile.


### PR DESCRIPTION
Most Vagrant users want to be able to 'vagrant up' the VM and demo the software. Most users are running on the 1.1+ syntax. Patch updates the syntax to v2.

http://docs.vagrantup.com/v2/vagrantfile/version.html
