### PR TITLE
CS-4956 & SITE-560 & IM-1355: Fixes issue with rich text captions

### DIFF
--- a/newscoop/admin-files/articles/images/edit.php
+++ b/newscoop/admin-files/articles/images/edit.php
@@ -35,6 +35,9 @@ if (!$g_user->hasPermission('ChangeImage')) {
 	$title = getGS('Change image information');
 }
 
+$richtextCaption = SystemPref::Get("MediaRichTextCaptions");
+$captionLimit = SystemPref::Get('MediaCaptionLength');
+
 // Add extra breadcrumb for image list.
 if ($f_publication_id > 0) {
 	$extraCrumbs = array(getGS("Images") => "");
@@ -64,7 +67,7 @@ if ($f_publication_id > 0) {
 </div>
 <p>
 <FORM NAME="dialog" METHOD="POST" ACTION="/<?php echo $ADMIN; ?>/articles/images/do_edit.php" onSubmit="<?php
-    if (SystemPref::Get("MediaRichTextCaptions") == 'Y') {
+    if ($richtextCaption == 'Y') {
         echo 'return validateTinyMCEEditors();';
     }
 ?>">
@@ -98,8 +101,7 @@ if ($f_publication_id > 0) {
 <TR>
 	<TD ALIGN="RIGHT" style="width:120px;"><?php
         putGS('Description');
-        $captionLimit = SystemPref::Get('MediaCaptionLength');
-        if ($g_user->hasPermission('ChangeImage') && SystemPref::Get("MediaRichTextCaptions") == 'Y' && $captionLimit > 0) {
+        if ($g_user->hasPermission('ChangeImage') && $richtextCaption == 'Y' && $captionLimit > 0) {
             echo '&nbsp;'; putGS('(max. $1 characters)', $captionLimit);
         }
     ?>:</TD>
@@ -107,8 +109,7 @@ if ($f_publication_id > 0) {
 		<?php
 			if ($g_user->hasPermission('ChangeImage')) {
 
-				$captionLimit = SystemPref::Get('MediaCaptionLength');
-			    if (SystemPref::Get("MediaRichTextCaptions") == 'Y') {
+			    if ($richtextCaption == 'Y') {
 
 			        $languageSelectedObj = new Language((int) camp_session_get('LoginLanguageId', 0));
 			        $editorLanguage = !empty($_COOKIE['TOL_Language']) ? $_COOKIE['TOL_Language'] : $languageSelectedObj->getCode();

--- a/newscoop/admin-files/media-archive/edit.php
+++ b/newscoop/admin-files/media-archive/edit.php
@@ -84,6 +84,9 @@ if ($g_user->hasPermission('ChangeImage')) {
 	$label_text = getGS('View image');
 }
 
+$richtextCaption = SystemPref::Get("MediaRichTextCaptions");
+$captionLimit = SystemPref::Get('MediaCaptionLength');
+
 include_once($GLOBALS['g_campsiteDir']."/$ADMIN_DIR/html_head.php");
 include_once($GLOBALS['g_campsiteDir']."/$ADMIN_DIR/javascript_common.php");
 
@@ -118,7 +121,7 @@ echo '<div class="toolbar clearfix"><span class="article-title">' . $label_text 
 <P>
 <?php if ($g_user->hasPermission('ChangeImage')) { ?>
 <FORM NAME="image_edit" METHOD="POST" ACTION="/<?php echo $ADMIN; ?>/media-archive/do_edit.php" ENCTYPE="multipart/form-data" onSubmit="<?php
-    if (SystemPref::Get("MediaRichTextCaptions") == 'Y') {
+    if ($richtextCaption == 'Y') {
         echo 'return validateTinyMCEEditors();';
     }
 ?>">
@@ -131,8 +134,7 @@ echo '<div class="toolbar clearfix"><span class="article-title">' . $label_text 
 	</TD>
 </TR>
 <?php
-    $captionLimit = SystemPref::Get('MediaCaptionLength');
-    if (SystemPref::Get("MediaRichTextCaptions") == 'Y') {
+    if ($richtextCaption == 'Y') {
 
         $languageSelectedObj = new Language((int) camp_session_get('LoginLanguageId', 0));
         $editorLanguage = !empty($_COOKIE['TOL_Language']) ? $_COOKIE['TOL_Language'] : $languageSelectedObj->getCode();
@@ -144,8 +146,7 @@ echo '<div class="toolbar clearfix"><span class="article-title">' . $label_text 
 <TR>
         <TD ALIGN="RIGHT" style="width:115px;"><?php
             putGS('Description');
-            $captionLimit = SystemPref::Get('MediaCaptionLength');
-            if (SystemPref::Get("MediaRichTextCaptions") == 'Y' && $captionLimit > 0) {
+            if ($richtextCaption == 'Y' && $captionLimit > 0) {
                 echo '&nbsp;'; putGS('(max. $1 characters)', $captionLimit);
             }
         ?>:</TD>

--- a/newscoop/admin-files/media-archive/editor_load_tinymce.php
+++ b/newscoop/admin-files/media-archive/editor_load_tinymce.php
@@ -134,7 +134,7 @@ function editor_load_tinymce($p_dbColumns, $p_user, $p_editorLanguage, $options=
         theme_advanced_statusbar_location: "<?php p($statusbar_location); ?>",
 
         // Limit characters
-        max_chars : 255,
+        max_chars : 0,
         max_chars_indicator : ".maxCharsSpan",
      
         // Example content CSS (should be your site CSS)
@@ -175,6 +175,12 @@ function editor_load_tinymce($p_dbColumns, $p_user, $p_editorLanguage, $options=
     };
 
     $.extend(tinyMceOptions, <?php echo $optionsAsJson; ?>);
+
+    // Remove option when value is  '0'. '0' indicates no character limit but
+    // plugin doesn't support this functionality.
+    if (tinyMceOptions.max_chars == 0) {
+        delete tinyMceOptions.max_chars;
+    }
  
     // Default skin
     tinyMCE.init(tinyMceOptions);
@@ -191,6 +197,10 @@ function editor_load_tinymce($p_dbColumns, $p_user, $p_editorLanguage, $options=
     ?>
 
     function validateTinyMCEEditors() {
+
+        if (typeof(tinyMceOptions.max_chars) == 'undefined') {
+            return true;
+        }
 
         var valid = true;
         var invalidInstances = [];

--- a/newscoop/application/modules/admin/controllers/ImageController.php
+++ b/newscoop/application/modules/admin/controllers/ImageController.php
@@ -258,11 +258,9 @@ class Admin_ImageController extends Zend_Controller_Action
                 if (isset($iptcDate)) {
                     $image->setDate($iptcDate);
                 }
-                
-                $images[] = $image;
-            }
 
-            if ($this->_getParam('force_edit')) {
+                $images[] = $image;
+            } elseif ($this->_getParam('force_edit')) {
                 $images[] = $image;
             }
         }

--- a/newscoop/application/modules/admin/views/scripts/image/edit-image-data.phtml
+++ b/newscoop/application/modules/admin/views/scripts/image/edit-image-data.phtml
@@ -7,6 +7,7 @@
     require_once($GLOBALS['g_campsiteDir']."/admin-files/media-archive/editor_load_tinymce.php");
 
     $loadAsRichtext = array();
+    $richtextCaption = SystemPref::Get("MediaRichTextCaptions");
     $captionLimit = SystemPref::Get('MediaCaptionLength');
 ?>
 
@@ -49,14 +50,13 @@
         <div class="image-data">
             <label for="" style="font-size: 11px;"><?php
                 echo(getGS('Description'));
-                $captionLimit = SystemPref::Get('MediaCaptionLength');
-                if (SystemPref::Get("MediaRichTextCaptions") == 'Y' && $captionLimit > 0) {
+                if ($richtextCaption == 'Y' && $captionLimit > 0) {
                     echo('&nbsp;'.getGS('(max. $1 characters)', $captionLimit));
                 }
             ?>: <a style="float: right;" href="javascript:useForAll('description', <?php echo $image->getId(); ?>);"> <?php echo(getGS('Use for all')); ?></a></label><br>
 
             <?php
-                if (SystemPref::Get("MediaRichTextCaptions") == 'Y') {
+                if ($richtextCaption == 'Y') {
 
                     $languageSelectedObj = new Language((int) camp_session_get('LoginLanguageId', 0));
                     $editorLanguage = !empty($_COOKIE['TOL_Language']) ? $_COOKIE['TOL_Language'] : $languageSelectedObj->getCode();
@@ -87,6 +87,7 @@
 </form>
 
 <?php
+
     // Load tinymce once for all textareas
     if (count($loadAsRichtext) > 0) {
 

--- a/newscoop/application/modules/admin/views/scripts/slideshow/edit-item.phtml
+++ b/newscoop/application/modules/admin/views/scripts/slideshow/edit-item.phtml
@@ -3,10 +3,13 @@
 <?php
     // Load tinymce for richtext editor
     require_once($GLOBALS['g_campsiteDir']."/admin-files/media-archive/editor_load_tinymce.php");
+
+    $richtextCaption = SystemPref::Get("MediaRichTextCaptions");
+    $captionLimit = SystemPref::Get('MediaCaptionLength');
 ?>
 <h1><?php putGS('Slideshow'); ?> <small id="slideshow-rendition-info"><?php echo $this->package->getRendition()->getInfo(); ?></small></h1>
 <form id="edit-form" method="<?php echo $this->form->getMethod(); ?>" onSubmit="<?php
-    if (SystemPref::Get("MediaRichTextCaptions") == 'Y') {
+    if ($richtextCaption == 'Y') {
         echo 'return validateTinyMCEEditors();';
     }
 ?>">
@@ -21,8 +24,7 @@
         <input type="text" name="url" value="<?php echo $this->escape($this->form->url->getValue()); ?>" />
         <?php } ?>
         <?php
-            $captionLimit = SystemPref::Get('MediaCaptionLength');
-            if (SystemPref::Get("MediaRichTextCaptions") == 'Y') {
+            if ($richtextCaption == 'Y') {
 
                 $languageSelectedObj = new Language((int) camp_session_get('LoginLanguageId', 0));
                 $editorLanguage = !empty($_COOKIE['TOL_Language']) ? $_COOKIE['TOL_Language'] : $languageSelectedObj->getCode();


### PR DESCRIPTION
Fixes:
- When rich text captions are enabled and value is set to 0, text fields
  were uneditable.
- Duplicate image metadata view, when editing metadata via the
  article edit screen, when only one image was attached to the
  article.
- The javascript error when rich text captions are enabled related
  to the previous mentioned bug.
- When uploading a new image via the article edit screen, the 'next'
  button would trigger a javascript error and the page would break.
