### PR TITLE
WOBS-3327: Adds parameter status to list_user_comments

### DIFF
--- a/newscoop/library/Newscoop/Services/CommentService.php
+++ b/newscoop/library/Newscoop/Services/CommentService.php
@@ -174,6 +174,10 @@ class CommentService
         $conditions = $qb->expr()->andx();
         $conditions->add($qb->expr()->in("c.commenter", $params["commenters"]));
 
+        if (array_key_exists('status', $params)) {
+            $conditions->add($qb->expr()->in("c.status", $params['status']));
+        }
+
         $qb->where($conditions);
 
         foreach ($order as $column => $direction) {

--- a/newscoop/template_engine/classes/UserCommentsList.php
+++ b/newscoop/template_engine/classes/UserCommentsList.php
@@ -133,6 +133,27 @@ class UserCommentsList extends ListObject
 	                   $parameters['commenters'] = $commenter_ids;
 	                }
                     break;
+                case 'status':
+                    $validValues = \Newscoop\Entity\Comment::$status_enum;
+
+                    if (is_array($value)) {
+                        foreach ($value AS $parameterKey => $parameterValue) {
+                            if (!in_array($parameterValue, $validValues)) {
+                                throw new \InvalidValueException("CommentsList Property '$parameter' has invalid value");
+                            } else {
+                                $value[$parameterKey] = array_search($parameterValue, $validValues);
+                            }
+                        }
+
+                        $parameters[$parameter] = $value;
+
+                    } elseif (!in_array($value, $validValues)) {
+                        throw new \InvalidValueException("CommentsList Property '$parameter' has invalid value");
+                    } else {
+                        $parameters[$parameter] = array(array_search($value, $validValues));
+                    }
+
+                    break;
 	            default:
 	                throw new \InvalidArgumentException("CommentsList Property '$parameter' invalid");
 	        }


### PR DESCRIPTION
The value of the parameter can either be a string or an array of strings. Valid values are the string
representations of the comment status found in the Comment entity.
