### PR TITLE
Xcache varsize issue

### DIFF
--- a/newscoop/library/Newscoop/Services/CacheService.php
+++ b/newscoop/library/Newscoop/Services/CacheService.php
@@ -53,7 +53,11 @@ class CacheService
                     $this->cacheDriver->setMemcached($memcached);
                     break;
                 case 'xcache':
-                    $this->cacheDriver = new \Doctrine\Common\Cache\XcacheCache();
+                    if (ini_get('xcache.var_size')) {
+                        $this->cacheDriver = new \Doctrine\Common\Cache\XcacheCache();
+                    } else {
+                        $this->cacheDriver = new \Doctrine\Common\Cache\ArrayCache();
+                    }
                     break;
                 case 'redis':
                     $redis = new \Redis();


### PR DESCRIPTION
Checks if xcache.varsize is set in the PHP INI to prevent XCache from loading if not available
