### PR TITLE
WOBS-3381: Replaces manual check if webcode exists with internal getWebcode() method

### DIFF
--- a/newscoop/library/Newscoop/Entity/Article.php
+++ b/newscoop/library/Newscoop/Entity/Article.php
@@ -1253,7 +1253,7 @@ class Article implements DocumentInterface
                 'published' => $this->published,
                 'indexed' => $this->indexed,
                 'type' => $this->type,
-                'webcode' => $this->webcode ? (string) $this->webcode : null,
+                'webcode' => $this->getWebcode(),
                 'publication_number' => $this->publication ? $this->publication->getId() : null,
                 'issue_number' => $this->issue ? $this->issue->getNumber() : null,
                 'section_number' => $this->section ? $this->section->getNumber() : null,


### PR DESCRIPTION
The method getWebcode already checks if the related entity webcode exists.
