### PR TITLE
IM-1941: Preview iFrame with protocol agnostic url

### DIFF
--- a/newscoop/admin-files/articles/preview.php
+++ b/newscoop/admin-files/articles/preview.php
@@ -121,6 +121,7 @@ if ($publicationObj->getUrlTypeId() == 1) {
 		$errorStr = $url->getMessage();
 	}
 	$url .= '?' . $accessParams;
+    $url = preg_replace('@^https?://@i', $scheme, $url);
 }
 
 $selectedLanguage = (int)CampRequest::GetVar('f_language_selected');


### PR DESCRIPTION
The iFrame url is now protocol agnostic, meaning it will adapt to the protocol of the parent including it. 
