### PR TITLE
Add posibility to check if plugin is installed and enabled from template

### DIFF
--- a/newscoop/template_engine/classes/CampContext.php
+++ b/newscoop/template_engine/classes/CampContext.php
@@ -1287,4 +1287,22 @@ final class CampContext
 
         return $this->userCount;
     }
+
+    /**
+     * Check if plugin is installed and enabled
+     *
+     * @param string $pluginName Plugin name ex. "vendor/plugin-name"
+     *
+     * @return boolean
+     */
+    public function isPluginEnabled($pluginName)
+    {
+        $pluginsService = \Zend_Registry::get('container')->get('newscoop.plugins.service');
+
+        if ($pluginsService->isInstalled($pluginName) && $pluginsService->isEnabled($pluginName)) {
+            return true;
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
## Check if plugin is installed and enabled from template.

In Our current newscoop themes we have this problem that we want to show all our features, also those provided by available plugins. So to run theme we need to setup first all required plugins. This takes time and can create issues for new users.

From 4.3 ([PR-800](https://github.com/sourcefabric/Newscoop/pull/800)) we can use special function in smarty templates to check if plugin is available and enable all cool features in theme. 

Use example:

```
{{ if $gimme->isPluginEnabled('newscoop/community-ticker-plugin') }}
   // show community ticker
{{ /if }}
```
