### PR TITLE
[WIP] Ddisable behat tests - update to a new version is required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_script:
   - sudo a2enmod rewrite
   - sudo service apache2 restart
   - mysql -e 'create database newscoop;' -uroot
-  - sudo cp -r dependencies/include/* newscoop/include/
   - cd newscoop/
   - composer install --prefer-dist
   - ./application/console newscoop:install --fix --database_name newscoop --database_user root


### PR DESCRIPTION
For now, behat test has been disabled from travis config file. We will need to upgrade Behat version to the latest one.
