### PR TITLE
CS-5584: Adds system preferences to template context

### DIFF
--- a/newscoop/template_engine/classes/CampContext.php
+++ b/newscoop/template_engine/classes/CampContext.php
@@ -1333,4 +1333,18 @@ final class CampContext
 
         return false;
     }
+
+    /**
+     * Check system preferences in smarty
+     *
+     * @param string $preferenceName Systempreferences machine name
+     * @param string $defaultValue   Default value if preference is null (not set)
+     *
+     * @return mixed
+     */
+    public function getSystemPreference($preferenceName, $default = null)
+    {
+        $preferencesService = \Zend_Registry::get('container')->get('preferences');
+        return $preferencesService->get($preferenceName, $default);
+    }
 }


### PR DESCRIPTION
It's now possible to use
  $gimme->getSystemPreference(preferenceName, defaultValue)
in the templates. For preference names the machine names should be
used. The default value will be returned if the preferences it not
set.
