### PR TITLE
CS-4766 Fix several issues with translation of support settings

### DIFF
--- a/newscoop/admin-style/form.css
+++ b/newscoop/admin-style/form.css
@@ -1,6 +1,6 @@
 
 dl.zend_form {
-    width: 410px;
+    width: 550px;
     margin: 0;
     padding: 10px;
     background-color: #fff;

--- a/newscoop/application/modules/admin/views/scripts/support/index.phtml
+++ b/newscoop/application/modules/admin/views/scripts/support/index.phtml
@@ -36,13 +36,13 @@ $this->placeholder('title')->set($translator->trans('Support Feedback', array(),
         } ?>
     <?php } ?>
 
-    <p><i><?php echo $translator->trans('By clicking on Yes, help Newscoop button, I agree to $1', array('$1' => '<a target="_blank" href="http://www.sourcefabric.org/en/about/policy/">Sourcefabric\'s privacy policy</a>'), 'support'); ?></i></p>
+    <p><i><?php echo $translator->trans('By clicking on the Yes, help Newscoop button, I agree to the Sourcefabric privacy policy', array(), 'support'); ?> <a target="_blank" href="http://www.sourcefabric.org/en/about/policy/">http://www.sourcefabric.org/en/about/policy/</a></i></p>
     
     <form method="post" id="support_send_form" action="<?php echo $this->url(array('controller' => 'support', 'action' => $this->action), 'admin'); ?>">
         <input type="hidden" id="stat_ask_time" name="stat_ask_time" value="7 days" />
         <input type="hidden" id="support_send" name="support_send" value="<?php echo($this->support_send); ?>">
         <input type="button" style="font-size: 12px; float: right;" class="save-button yes" value="<?php echo $this->escape($translator->trans('Yes, help Newscoop', array(), 'support')); ?>">
-        <input type="button" style="font-size: 12px; float: right;" class="save-button never" value="<?php echo $this->escape($translator->trans("Don't remind me", array(), 'support')); ?>">
+        <input type="button" style="font-size: 12px; float: right;" class="save-button never" value="<?php echo $this->escape($translator->trans("Do not remind me", array(), 'support')); ?>">
         <input type="button" style="font-size: 12px; float: right;" class="save-button" value="<?php echo $this->escape($translator->trans('Remind me in 1 week', array(), 'support')); ?>">
         <div style="clear: both;"></div>
     </form>

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.ar.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.ar.yml
@@ -1,4 +1,4 @@
-'Dont remind me': 'لا تذكّر لي'
+'Do not remind me': 'لا تذكّر لي'
 'You are sending daily statistics.': 'أنت ترسل إحصائيات يومية'
 'You are NOT sending daily statistics.': 'أنت لا ترسل إحصائيات يومية'
 'Yes, help Newscoop': 'نعم، مساعدة نيوسكوب'
@@ -9,4 +9,4 @@
 'Hide feedback data': 'أخف بيانات التقييم'
 'Help Newscoop improve by letting us know you are using it. This info will be collected regularly in order to improve your user experience.': 'ساعد نيوسكوب  أن يتحسن بواسطة إطلاعنا بأن تستعمله. سوف تتجمع هذه المعلومات بانتظام لكي تتحسن خبرة المستخدم.'
 'Current status: ': 'الحالة الحالية'
-'By clicking on Yes, help Newscoop button, I agree to $1': 'بالضغط على نعم، سأساعد Newscoop، انا أوافق على $1'
+'By clicking on the Yes, help Newscoop button, I agree to the Sourcefabric privacy policy': 'بالضغط على نعم، سأساعد Newscoop، انا أوافق على Sourcefabric privacy policy'

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.az.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.az.yml
@@ -1,4 +1,4 @@
-'Dont remind me': 'Mənim yadıma salma'
+'Do not remind me': 'Mənim yadıma salma'
 'You are sending daily statistics.': 'Sən gündəlik statistika göndərirsən.'
 'You are NOT sending daily statistics.': 'Sən gündəlik statistika GÖNDƏRMİRSƏN.'
 'Yes, help Newscoop': 'Bəli, Newscoop-a dəstək ol'
@@ -9,4 +9,4 @@
 'Hide feedback data': 'Rəy məlumatını gizlə'
 'Help Newscoop improve by letting us know you are using it. This info will be collected regularly in order to improve your user experience.': 'Newscoop-u istifadə etdiyini bizə bildirməklə onu inkişaf etdirməyimizə dəstək ol. Bu məlumatlaq sənin istifadəçi fikirlərini yaxşılaşdırmaq üçün toplanacaqdır.'
 'Current status: ': 'Mövcud status:'
-'By clicking on Yes, help Newscoop button, I agree to $1': 'Bəli düyməsini klikləməklə, Newscoop-a dəstək düyməsi ilə razılaşıram ki, $1'
+'By clicking on the Yes, help Newscoop button, I agree to the Sourcefabric privacy policy': 'Bəli düyməsini klikləməklə, Newscoop-a dəstək düyməsi ilə razılaşıram ki, Sourcefabric privacy policy'

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.be.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.be.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.bn.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.bn.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.cs.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.cs.yml
@@ -1,4 +1,4 @@
-'Dont remind me': Nepřipomenout
+'Do not remind me': Nepřipomenout
 'You are sending daily statistics.': 'Posíláte denní satistiky'
 'You are NOT sending daily statistics.': 'Neposíláte denní statistiky'
 'Yes, help Newscoop': 'Ano, pomozte Newscoop'
@@ -9,4 +9,4 @@
 'Hide feedback data': 'Skrýt data zpětné vazby'
 'Help Newscoop improve by letting us know you are using it. This info will be collected regularly in order to improve your user experience.': 'Pomozte Newscoop se zdokonalit tím, že nám dáte vědět o jeho využívání. Tato informace bude se sbírána pravidelně, pro zlepšení vaší uživatelské zkušenosti.'
 'Current status: ': 'Současný status:'
-'By clicking on Yes, help Newscoop button, I agree to $1': 'Kliknutím na Ano, pomož Newscoop tlačítko, souhlasim s  $1'
+'By clicking on the Yes, help Newscoop button, I agree to the Sourcefabric privacy policy': 'Kliknutím na Ano, pomož Newscoop tlačítko, souhlasim s Sourcefabric privacy policy'

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.da.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.da.yml
@@ -1,4 +1,4 @@
-'Dont remind me': 'Påmind mig ikke'
+'Do not remind me': 'Påmind mig ikke'
 'You are sending daily statistics.': 'Du sender daglig statistik.'
 'You are NOT sending daily statistics.': 'Du sender IKKE daglig statistik.'
 'Yes, help Newscoop': 'Ja, hjælp Newscoop'
@@ -9,4 +9,4 @@
 'Hide feedback data': 'Skjul feedback data'
 'Help Newscoop improve by letting us know you are using it. This info will be collected regularly in order to improve your user experience.': 'Hjælp os ved at automatisk at sende os information om hvordan du bruger Newscoop.'
 'Current status: ': 'Nuværende status:'
-'By clicking on Yes, help Newscoop button, I agree to $1': 'Ved at trykke på Ja, hjælp Newscoop knappen indvilger du i $1'
+'By clicking on the Yes, help Newscoop button, I agree to the Sourcefabric privacy policy': 'Ved at trykke på Ja, hjælp Newscoop knappen indvilger du i Sourcefabric privacy policy'

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.de.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.de.yml
@@ -1,4 +1,4 @@
-'Dont remind me': 'Nicht erinnern. '
+'Do not remind me': 'Nicht erinnern. '
 'You are sending daily statistics.': 'Sie senden tägliche Statistiken. '
 'You are NOT sending daily statistics.': 'Sie senden keine täglichen Statistiken '
 'Yes, help Newscoop': 'Ja, Newscoop unterstützen. '
@@ -9,4 +9,4 @@
 'Hide feedback data': 'Feedbackdaten verstecken'
 'Help Newscoop improve by letting us know you are using it. This info will be collected regularly in order to improve your user experience.': 'Helfen Sie Newscoop indem Sie uns Nutzungsstatistiken senden. Diese Info soll uns helfen, Ihre User Experience zu verbessern. '
 'Current status: ': 'Aktueller Status: '
-'By clicking on Yes, help Newscoop button, I agree to $1': 'Indem Sie auf  den Ja, Newscoop unterstützen Button klicken, stimmen Sie  $1 zu'
+'By clicking on the Yes, help Newscoop button, I agree to the Sourcefabric privacy policy': 'Indem Sie auf den Ja, Newscoop unterstützen Button klicken, stimmen Sie Sourcefabric privacy policy zu'

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.de_AT.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.de_AT.yml
@@ -1,4 +1,4 @@
-'Dont remind me': 'Nicht erinnern. '
+'Do not remind me': 'Nicht erinnern. '
 'You are sending daily statistics.': 'Sie senden tägliche Statistiken. '
 'You are NOT sending daily statistics.': 'Sie senden keine täglichen Statistiken '
 'Yes, help Newscoop': 'Ja, Newscoop unterstützen. '
@@ -9,4 +9,4 @@
 'Hide feedback data': 'Feedbackdaten verstecken'
 'Help Newscoop improve by letting us know you are using it. This info will be collected regularly in order to improve your user experience.': 'Helfen Sie Newscoop indem Sie uns Nutzungsstatistiken senden. Diese Info soll uns helfen, Ihre User Experience zu verbessern. '
 'Current status: ': 'Aktueller Status: '
-'By clicking on Yes, help Newscoop button, I agree to $1': 'Indem Sie auf  den Ja, Newscoop unterstützen Button klicken, stimmen Sie  $1 zu'
+'By clicking on the Yes, help Newscoop button, I agree to the Sourcefabric privacy policy': 'Indem Sie auf  den Ja, Newscoop unterstützen Button klicken, stimmen Sie Sourcefabric privacy policy zu'

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.el.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.el.yml
@@ -1,4 +1,4 @@
-'Dont remind me': 'Δεν επιθυμώ υπενθύμιση'
+'Do not remind me': 'Δεν επιθυμώ υπενθύμιση'
 'You are sending daily statistics.': 'Στέλνετε ημερήσιες στατιστικές.'
 'You are NOT sending daily statistics.': 'ΔΕΝ στέλνετε  ημερήσιες στατιστικές.'
 'Yes, help Newscoop': 'Ναί, βοηθώ το Newscoop'
@@ -9,4 +9,4 @@
 'Hide feedback data': 'Απόκρυψη δεδομένων feedback'
 'Help Newscoop improve by letting us know you are using it. This info will be collected regularly in order to improve your user experience.': 'Βοηθήστε μας να βελτιώσουμε το Newscoop με το να μας ενημερώνετε πως το χρησιμοποιείτε. Αυτές οι πληροφορίες θα συλλέγονται τακτικά για να να βελτιωθεί η εμπειρία του χρήστη.'
 'Current status: ': 'Προσωρινή κατάσταση:'
-'By clicking on Yes, help Newscoop button, I agree to $1': 'Κάνοντας κλίκ στο Ναί, βοηθώ το Newscoop, συμφωνώ με $1'
+'By clicking on the Yes, help Newscoop button, I agree to the Sourcefabric privacy policy': 'Κάνοντας κλίκ στο Ναί, βοηθώ το Newscoop, συμφωνώ με Sourcefabric privacy policy'

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.en.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.en.yml
@@ -1,4 +1,4 @@
-'Dont remind me': 'Dont remind me'
+'Do not remind me': 'Do not remind me'
 'You are sending daily statistics.': 'You are sending daily statistics.'
 'You are NOT sending daily statistics.': 'You are NOT sending daily statistics.'
 'Yes, help Newscoop': 'Yes, help Newscoop'
@@ -9,4 +9,4 @@
 'Hide feedback data': 'Hide feedback data'
 'Help Newscoop improve by letting us know you are using it. This info will be collected regularly in order to improve your user experience.': 'Help Newscoop improve by letting us know you are using it. This info will be collected regularly in order to improve your user experience.'
 'Current status: ': 'Current status: '
-'By clicking on Yes, help Newscoop button, I agree to $1': 'By clicking on Yes, help Newscoop button, I agree to $1'
+'By clicking on the Yes, help Newscoop button, I agree to the Sourcefabric privacy policy': 'By clicking on the Yes, help Newscoop button, I agree to the Sourcefabric privacy policy'

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.en_GB.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.en_GB.yml
@@ -1,4 +1,4 @@
-'Dont remind me': 'Dont remind me'
+'Do not remind me': 'Do not remind me'
 'You are sending daily statistics.': 'You are sending daily statistics.'
 'You are NOT sending daily statistics.': 'You are NOT sending daily statistics.'
 'Yes, help Newscoop': 'Yes, help Newscoop'
@@ -9,4 +9,4 @@
 'Hide feedback data': 'Hide feedback data'
 'Help Newscoop improve by letting us know you are using it. This info will be collected regularly in order to improve your user experience.': 'Help Newscoop improve by letting us know you are using it. This info will be collected regularly in order to improve your user experience.'
 'Current status: ': 'Current status: '
-'By clicking on Yes, help Newscoop button, I agree to $1': 'By clicking on Yes, help Newscoop button, I agree to $1'
+'By clicking on the Yes, help Newscoop button, I agree to the Sourcefabric privacy policy': 'By clicking on the Yes, help Newscoop button, I agree to the Sourcefabric privacy policy'

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.es.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.es.yml
@@ -1,4 +1,4 @@
-'Dont remind me': 'No mandarme recordatorios'
+'Do not remind me': 'No mandarme recordatorios'
 'You are sending daily statistics.': 'Está enviando las estadísticas diarias'
 'You are NOT sending daily statistics.': 'No está enviando las estadísticas diarias.'
 'Yes, help Newscoop': 'Sì, ayuda a Newscoop'
@@ -9,4 +9,4 @@
 'Hide feedback data': 'Ocultar los datos de retroalimentación'
 'Help Newscoop improve by letting us know you are using it. This info will be collected regularly in order to improve your user experience.': 'Ayúdenos a mejorar Newscoop haciéndonos saber que lo está utilizando.  Esta información se recolectará regularmente, con miras a mejorar la experiencia de nuestros usuarios.'
 'Current status: ': 'Estatus actual:'
-'By clicking on Yes, help Newscoop button, I agree to $1': 'Al hacer click en en el botón de "Si, ayuda a Newscoop", indica estar de acuerdo con 1$'
+'By clicking on the Yes, help Newscoop button, I agree to the Sourcefabric privacy policy': 'Al hacer click en en el botón de "Si, ayuda a Newscoop", indica estar de acuerdo con Sourcefabric privacy policy'

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.fr.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.fr.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.he.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.he.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.hr.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.hr.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.hu.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.hu.yml
@@ -1,4 +1,4 @@
-'Dont remind me': 'Ne emlékeztessen'
+'Do not remind me': 'Ne emlékeztessen'
 'You are sending daily statistics.': 'Te napi statisztikákat küldesz.'
 'You are NOT sending daily statistics.': 'Te NEM küldesz napi statisztikákat.'
 'Yes, help Newscoop': 'Igen, segítek a Newscoop fejlesztésében'
@@ -9,4 +9,4 @@
 'Hide feedback data': 'Visszajelzési adatok elrejtése'
 'Help Newscoop improve by letting us know you are using it. This info will be collected regularly in order to improve your user experience.': 'Segítsd a Newscoop fejlesztését azzal, hogy tudatsz minket a használatáról. Ezek az adatok rendszeresen kerülnek gyűjtésre, hogy javítsák a felhasználói élményedet.'
 'Current status: ': 'Jelenlegi állapot: '
-'By clicking on Yes, help Newscoop button, I agree to $1': 'Az Igenre kattintással, a Newscoop-gomb segítségével, elfogadom, hogy $1'
+'By clicking on the Yes, help Newscoop button, I agree to the Sourcefabric privacy policy': 'Az Igenre kattintással, a Newscoop-gomb segítségével, elfogadom, hogy Sourcefabric privacy policy'

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.hy.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.hy.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.hy_AM.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.hy_AM.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.id.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.id.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.it.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.it.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': 'Stai inviando le statistiche giornaliere.'
 'You are NOT sending daily statistics.': 'NON stai inviando le statistiche giornaliere.'
 'Yes, help Newscoop': 'Sì, aiuta Newscoop'

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.ka.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.ka.yml
@@ -1,4 +1,4 @@
-'Dont remind me': 'არ შემახსენოთ'
+'Do not remind me': 'არ შემახსენოთ'
 'You are sending daily statistics.': 'თქვენ აგზავნით ყოველდღიურ სტატისტიკას. '
 'You are NOT sending daily statistics.': 'თქვენ აგზავნით ყოველდღიურ სტატისტიკას. '
 'Yes, help Newscoop': 'დიახ, დავეხმაროთ Newscoop-ს'
@@ -9,4 +9,4 @@
 'Hide feedback data': 'შეფასების მონაცემების დაფარვა'
 'Help Newscoop improve by letting us know you are using it. This info will be collected regularly in order to improve your user experience.': 'დაეხმარეთ ნიუსქუპს გაუმჯობესდეს და შეგვატყობინეთ, რომ თქვენ მისი მომხმარებელი ხართ. ინფორმაცია რეგულარულად შეგროვდება რათა გავაუმჯობესოთ თქვენი როგორც მომხმარებლის გამოცდილება'
 'Current status: ': 'ამჟამინდელი სტატუსი:'
-'By clicking on Yes, help Newscoop button, I agree to $1': 'დიას, დავეხმაროთ Newscoop-ს ღილაკზე დაჭერით, მე ვეთანხმები $1'
+'By clicking on the Yes, help Newscoop button, I agree to the Sourcefabric privacy policy': 'დიას, დავეხმაროთ Newscoop-ს ღილაკზე დაჭერით, მე ვეთანხმები Sourcefabric privacy policy'

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.ko.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.ko.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.ku.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.ku.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.nb_NO.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.nb_NO.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.nl.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.nl.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.pl.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.pl.yml
@@ -1,4 +1,4 @@
-'Dont remind me': 'Nie przypominaj mi'
+'Do not remind me': 'Nie przypominaj mi'
 'You are sending daily statistics.': 'Wysyłasz dzienne statystyki.'
 'You are NOT sending daily statistics.': 'NIE wysyłasz dziennych statystyk.'
 'Yes, help Newscoop': 'Tak, pomóż Newscoopowi'
@@ -9,4 +9,4 @@
 'Hide feedback data': 'Ukryj dane'
 'Help Newscoop improve by letting us know you are using it. This info will be collected regularly in order to improve your user experience.': 'Pomóż nam ulepszać Newsoopa mówiac nam jak go używasz. Te informacje będą zbierane regularnie w celu poprawienia twoich doświadczeń użytkowania.'
 'Current status: ': 'Aktualny status'
-'By clicking on Yes, help Newscoop button, I agree to $1': 'Klikając Tak, pomóż Newscoopowi zgadzasz się na $1'
+'By clicking on the Yes, help Newscoop button, I agree to the Sourcefabric privacy policy': 'Klikając Tak, pomóż Newscoopowi zgadzasz się na Sourcefabric privacy policy'

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.pt.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.pt.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.pt_BR.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.pt_BR.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.ro.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.ro.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.ru.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.ru.yml
@@ -1,4 +1,4 @@
-'Dont remind me': 'Не напоминать мне'
+'Do not remind me': 'Не напоминать мне'
 'You are sending daily statistics.': 'Вы отправляете ежеденевную статистику.'
 'You are NOT sending daily statistics.': 'Вы НЕ отправляете ежеденевную статистику.'
 'Yes, help Newscoop': 'Да, помогите Newscoop'

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.sh.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.sh.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.sq.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.sq.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.sr.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.sr.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.sv.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.sv.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.tr.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.tr.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.uk.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.uk.yml
@@ -1,4 +1,4 @@
-'Dont remind me': 'Не нагадувати мені'
+'Do not remind me': 'Не нагадувати мені'
 'You are sending daily statistics.': 'Ви відправляєте щоденну статистику.'
 'You are NOT sending daily statistics.': 'Ви не відправляєте щоденну статистику.'
 'Yes, help Newscoop': 'Так, допомогти Newscoop'

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.zh.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.zh.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.zh_TW.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/support.zh_TW.yml
@@ -1,4 +1,4 @@
-'Dont remind me': null
+'Do not remind me': null
 'You are sending daily statistics.': null
 'You are NOT sending daily statistics.': null
 'Yes, help Newscoop': null


### PR DESCRIPTION
This pull request fixes several issues outlined in ticket CS-4766...
1. The support settings box was not wide enough for the number of blue buttons we have now, especially when a language is more verbose (e.g. German)
2. Because the words 'Sourcefabric's privacy policy' were within a HTML tag which was not part of the string, they could not be translated
3. The string 'Don't remind me' was not working in YML format because of the apostrophe, it has been changed to 'Do not remind me' as a workaround
