### PR TITLE
TW-25

### DIFF
--- a/newscoop/admin-files/media-archive/do_upload.php
+++ b/newscoop/admin-files/media-archive/do_upload.php
@@ -69,11 +69,19 @@ for ($i = 0; $i < $nrOfFiles; $i++) {
     $statusIdx = 'uploader_' . $i . '_status';
     if ($params[$statusIdx] == 'done') {
         $fileLocation = $imageService->getImagePath() . $params[$tmpnameIdx];
-        $mime = getimagesize($fileLocation);
-        $file = new UploadedFile($fileLocation, $params[$nameIdx], $mime['mime'], filesize($fileLocation), null, true);
-        $result = $imageService->upload($file, array('user' => $user));
-        $result->setDate('0000-00-00');
-        $images[] = $result;
+
+        if (file_exists($fileLocation) && is_readable($fileLocation)) {
+            $mime = getimagesize($fileLocation);
+            $file = new UploadedFile($fileLocation, $params[$nameIdx], $mime['mime'], filesize($fileLocation), null, true);
+            $result = $imageService->upload($file, array('user' => $user));
+            $result->setDate('0000-00-00');
+            $images[] = $result;
+        } else {
+            camp_html_add_msg($translator->trans("An error occured while uploading the file $1", array('$1' => $params[$nameIdx]), 'media_archive'));
+            if ($nrOfFiles == 1) {
+                camp_html_goto_page("/$ADMIN/media-archive/add.php", true);
+            }
+        }
     }
 }
 

--- a/newscoop/admin-files/media-archive/do_upload_file.php
+++ b/newscoop/admin-files/media-archive/do_upload_file.php
@@ -41,8 +41,15 @@ for ($i = 0; $i < $nrOfFiles; $i++) {
     $statusIdx = 'uploader_' . $i . '_status';
     if ($params[$statusIdx] == 'done') {
         $fileLocation = $attachmentService->getStorageLocation(new \Newscoop\Entity\Attachment()).'/'.$params[$tmpnameIdx];
-        $file = new UploadedFile($fileLocation, $params[$nameIdx], mime_content_type($fileLocation), filesize($fileLocation), null, true);
-        $result = $attachmentService->upload($file, '', $language, array('user' => $user));
+        if (file_exists($fileLocation) && is_readable($fileLocation)) {
+            $file = new UploadedFile($fileLocation, $params[$nameIdx], mime_content_type($fileLocation), filesize($fileLocation), null, true);
+            $result = $attachmentService->upload($file, '', $language, array('user' => $user));
+        } else {
+            camp_html_add_msg($translator->trans("An error occured while uploading the file $1", array('$1' => $params[$nameIdx]), 'media_archive'));
+            if ($nrOfFiles == 1) {
+                camp_html_goto_page("/$ADMIN/media-archive/add_file.php", true);
+            }
+        }
     }
 }
 

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/media_archive.en.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/media_archive.en.yml
@@ -60,3 +60,4 @@ Size: Size
 'Change image information': 'Change image information'
 'Photographer URL': 'Photographer URL'
 'Add website url starting with http://': 'Add website url starting with http://'
+'An error occured while uploading the file $1': 'An error occured while uploading the file $1'


### PR DESCRIPTION
Adds error handling when files are not correctly uploaded. Sometime the status reflects _done_, but the actualy file it not uploaded/not readable, in any case Newscoop trips over it. This will prevent the file from being added to the database and present the user with an error message. The re-upload works in all reported cases from clients.
