### PR TITLE
CS-5595 Proposed fix for missing image captions table in core SQL

### DIFF
--- a/newscoop/install/Resources/sql/campsite_core.sql
+++ b/newscoop/install/Resources/sql/campsite_core.sql
@@ -82,6 +82,33 @@ LOCK TABLES `ArticleAuthors` WRITE;
 UNLOCK TABLES;
 
 --
+-- Table structure for table `ArticleImageCaptions`
+--
+
+DROP TABLE IF EXISTS `ArticleImageCaptions`;
+
+CREATE TABLE `ArticleImageCaptions` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `IdLanguage` int(11) NOT NULL,
+  `IdImage` int(11) NOT NULL,
+  `NrArticle` int(11) NOT NULL,
+  `caption` varchar(255) NOT NULL,
+  `articleImage_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `imageId` (`IdImage`,`NrArticle`,`IdLanguage`),
+  KEY `IDX_1E9BFCA410F3034D6CB384EF` (`IdImage`,`NrArticle`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=10 ;
+
+--
+-- Dumping data for table `ArticleImageCaptions`
+--
+
+LOCK TABLES `ArticleImageCaptions` WRITE;
+/*!40000 ALTER TABLE `ArticleImageCaptions` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ArticleImageCaptions` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
 -- Table structure for table `ArticleImages`
 --
 


### PR DESCRIPTION
I am no expert on SQL, but this patch fixes the issue CS-5595 for me. Copied from newscoop/install/Resources/sql/upgrade/4.3.x/2014.03.12/tables.sql and formatted for core. Tested on my local machine by pasting the SQL into a running 4.3.1 database. 
