### PR TITLE
add fallback language (the same as translator fallback) to js translation co...

### DIFF
--- a/newscoop/application/configs/symfony/config.yml
+++ b/newscoop/application/configs/symfony/config.yml
@@ -170,6 +170,9 @@ newscoop_gimme:
     allow_origin:
         - "*"
 
+bazinga_js_translation:
+    locale_fallback: en
+
 nelmio_api_doc:
     name:                     Newscoop REST API documentation
     request_listener:


### PR DESCRIPTION
...nfig


Added recommened fallback to js translation set to the same locale that symfony translator is using.