### PR TITLE
improve displaying blank avatars for users on frontend

### DIFF
--- a/newscoop/application/controllers/RegisterController.php
+++ b/newscoop/application/controllers/RegisterController.php
@@ -26,7 +26,7 @@ class RegisterController extends Zend_Controller_Action
     }
 
     public function indexAction()
-    {   
+    {
         $translator = \Zend_Registry::get('container')->getService('translator');
         $form = new Application_Form_Register();
         $form->setMethod('POST');
@@ -55,21 +55,21 @@ class RegisterController extends Zend_Controller_Action
 
         $this->view->form = $form;
     }
-    
+
     public function createUserAction()
     {
         $parameters = $this->getRequest()->getParams();
-        
+
         $user = $this->_helper->service('user')->findBy(array(
             'email' => $parameters['email'],
         ));
-        
+
         if ($user) {
             echo '0';
             exit;
         } else {
             $user = $this->_helper->service('user')->createPending($parameters['email'], $parameters['first_name'], $parameters['last_name'], $parameters['subscriber_id']);
-            
+
             $this->_helper->service('email')->sendConfirmationToken($user);
             echo '1';
             exit;
@@ -107,8 +107,6 @@ class RegisterController extends Zend_Controller_Action
                 if (!empty($values['image'])) {
                     $imageInfo = array_pop($form->image->getFileInfo());
                     $values['image'] = $this->_helper->service('image')->save($imageInfo);
-                } else {
-                    $values['image'] = $this->getUserImageFilename($user);
                 }
 
                 $this->_helper->service('user')->savePending($values, $user);
@@ -137,37 +135,8 @@ class RegisterController extends Zend_Controller_Action
         }
 
         $this->view->form = $form;
-        $this->view->img = $this->getUserImageSrc($user);
         $this->view->user = new \MetaUser($user);
         $this->view->social = $social ?: false;
-    }
-
-  /**
-     * Get user image filename
-     *
-     * @param Newscoop\Entity\User $user
-     *
-     * @return string
-     */
-    private function getUserImageFilename(User $user)
-    {
-        $num = $user->getId() % 6;
-
-        return "user_placeholder_{$num}.png";
-    }
-
-    /**
-     * Get user image src
-     *
-     * @param Newscoop\Entity\User $user
-     *
-     * @return string
-     */
-    private function getUserImageSrc(User $user)
-    {
-        return $this->view->url(array(
-            'src' => $this->getHelper('service')->getService('image')->getSrc('images/' . $this->getUserImageFilename($user), 125, 125, 'fit'),
-        ), 'image', false, false);
     }
 
     public function generateUsernameAction()
@@ -198,6 +167,7 @@ class RegisterController extends Zend_Controller_Action
             $user = array_pop($users);
             if (!$user->isPending()) {
                 $this->view->status = false;
+
                 return;
             }
         }
@@ -209,11 +179,10 @@ class RegisterController extends Zend_Controller_Action
     {
         if ($this->_getParam('email')) {
             $user = $this->_helper->service('user')->findBy(array('email' => $this->_getParam('email')));
-            
+
             if ($user) {
                 $this->view->result = '0';
-            }
-            else {
+            } else {
                 $user = $this->_helper->service('user')->createPending($this->_getParam('email'));
                 $this->_helper->service('email')->sendConfirmationToken($user);
                 $this->view->result = '1';

--- a/newscoop/template_engine/metaclasses/MetaUser.php
+++ b/newscoop/template_engine/metaclasses/MetaUser.php
@@ -221,10 +221,16 @@ final class MetaUser extends MetaDbObject implements ArrayAccess
         $imageService = \Zend_Registry::get('container')->getService('image');
         $themesService = \Zend_Registry::get('container')->getService('newscoop_newscoop.themes_service');
         $num = $this->m_dbObject->getId() % 6;
+        $themePath = 'themes/' . $themesService->getThemePath();
         $imagePath = is_null($imagePath) ? "_img/user_placeholder_{$num}.png" : $imagePath;
+
+        if (!file_exists(APPLICATION_PATH . '/../' . $themePath . $imagePath)) {
+            return '';
+        }
+
         if (!$this->m_dbObject->getImage()) {
             return $zendRouter->assemble(array(
-                'src' => $imageService->getSrc('themes/' . $themesService->getThemePath() . $imagePath, $width, $height, $specs),
+                'src' => $imageService->getSrc($themePath . $imagePath, $width, $height, $specs),
             ), 'image', false, false);
         }
 

--- a/newscoop/template_engine/metaclasses/MetaUser.php
+++ b/newscoop/template_engine/metaclasses/MetaUser.php
@@ -210,18 +210,26 @@ final class MetaUser extends MetaDbObject implements ArrayAccess
      *
      * @param  int    $width
      * @param  int    $height
+     * @param  string $specs
+     * @param  string $imagePath
+     *
      * @return string
      */
-    public function image($width = 80, $height = 80, $specs = 'fit')
+    public function image($width = 80, $height = 80, $specs = 'fit', $imagePath = null)
     {
+        $zendRouter = \Zend_Registry::get('container')->getService('zend_router');
+        $imageService = \Zend_Registry::get('container')->getService('image');
+        $themesService = \Zend_Registry::get('container')->getService('newscoop_newscoop.themes_service');
+        $num = $this->m_dbObject->getId() % 6;
+        $imagePath = is_null($imagePath) ? "_img/user_placeholder_{$num}.png" : $imagePath;
         if (!$this->m_dbObject->getImage()) {
-            return '';
+            return $zendRouter->assemble(array(
+                'src' => $imageService->getSrc('themes/' . $themesService->getThemePath() . $imagePath, $width, $height, $specs),
+            ), 'image', false, false);
         }
 
-        $container = \Zend_Registry::get('container');
-
-        return $container->get('zend_router')->assemble(array(
-            'src' => $container->getService('image')->getSrc('images/' . $this->m_dbObject->getImage(), $width, $height, $specs),
+        return $zendRouter->assemble(array(
+            'src' => $imageService->getSrc('images/' . $this->m_dbObject->getImage(), $width, $height, $specs),
         ), 'image', false, false);
     }
 

--- a/newscoop/template_engine/metaclasses/MetaUser.php
+++ b/newscoop/template_engine/metaclasses/MetaUser.php
@@ -220,22 +220,23 @@ final class MetaUser extends MetaDbObject implements ArrayAccess
         $zendRouter = \Zend_Registry::get('container')->getService('zend_router');
         $imageService = \Zend_Registry::get('container')->getService('image');
         $themesService = \Zend_Registry::get('container')->getService('newscoop_newscoop.themes_service');
-        $num = $this->m_dbObject->getId() % 6;
         $themePath = 'themes/' . $themesService->getThemePath();
-        $imagePath = is_null($imagePath) ? "_img/user_placeholder_{$num}.png" : $imagePath;
 
-        if (!file_exists(APPLICATION_PATH . '/../' . $themePath . $imagePath)) {
+        if (!$this->m_dbObject->getImage() && is_null($imagePath)) {
             return '';
         }
 
-        if (!$this->m_dbObject->getImage()) {
-            return $zendRouter->assemble(array(
-                'src' => $imageService->getSrc($themePath . $imagePath, $width, $height, $specs),
-            ), 'image', false, false);
+        $src = null;
+        if ($this->m_dbObject->getImage()) {
+            $src = $imageService->getSrc('images/' . $this->m_dbObject->getImage(), $width, $height, $specs);
+        }
+
+        if ($imagePath && file_exists(APPLICATION_PATH . '/../' . $themePath . $imagePath)) {
+            $src = $imageService->getSrc($themePath . $imagePath, $width, $height, $specs);
         }
 
         return $zendRouter->assemble(array(
-            'src' => $imageService->getSrc('images/' . $this->m_dbObject->getImage(), $width, $height, $specs),
+            'src' => $src,
         ), 'image', false, false);
     }
 


### PR DESCRIPTION
***Benefits:***
- displaying user image's logic is simpler
- let's you read and resize images from the current theme directory
- images for each resolution are not required anymore (user_blank_120x120.jpg, user_blank_60x60.jpg etc)

This improvement lets you have more control over user avatars. It lets you read and crop images also from `themes` directory. You can now pass 3rd argument with default avatar path, for example:

```
{{ $user->image($height, $width, 'fit', '_img/user-thumb.jpg') }}
```
It means that file `user-thumb.jpg` from current theme (e.g `themes/publication_1/theme_1/_img/user-thumb.jpg`) will be taken and cropped by given `$height` and `$width`. 

If user has profile image, then to simply display it use (like it was before):
```
{{ $user->image($height, $width) }}
```

***Example snippet:***
```
{{ $num = $user->identifier % 6 }}

{{ if $user->image() }}
{{ $user->image($width, $height, 'crop') }}
{{ else }}
{{ $user->image($width, $height, 'crop', "_css/img/user_placeholder_`$num`.png") }}
{{ /if }}
```

The above snippet displays user image, if user uploaded one, else it will display default user image from current theme directory and it will be automatically cropped.

