### PR TITLE
CS-5599: Create Newscoop Plugin Generator

### DIFF
--- a/newscoop/application/AppKernel.php
+++ b/newscoop/application/AppKernel.php
@@ -37,7 +37,9 @@ class AppKernel extends Kernel
             new Newscoop\NewscoopBundle\NewscoopNewscoopBundle(),
             new Newscoop\CommunityTickerBundle\NewscoopCommunityTickerBundle(),
             new Newscoop\ArticlesBundle\NewscoopArticlesBundle(),
-            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle()
+            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
+            new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle(),
+            new Newscoop\PluginGeneratorBundle\NewscoopPluginGeneratorBundle()
         );
 
         if (in_array($this->getEnvironment(), array('dev', 'test'))) {

--- a/newscoop/src/Newscoop/NewscoopBundle/Controller/PluginsController.php
+++ b/newscoop/src/Newscoop/NewscoopBundle/Controller/PluginsController.php
@@ -120,6 +120,8 @@ class PluginsController extends Controller
         @apache_setenv('no-gzip', 1);
         @ini_set('implicit_flush', 1);
 
+        ob_start();
+
         $response = new Response();
         $response->sendHeaders();
 

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Command/GeneratePluginBundleCommand.php
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Command/GeneratePluginBundleCommand.php
@@ -1,0 +1,312 @@
+<?php
+/*
+ * This file is part of the NewscooPluginGeneratorBundle package.
+ *
+ * (c) Mark Lewis <mark.lewis@sourcefabric.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Newscoop\PluginGeneratorBundle\Command;
+use Newscoop\PluginGeneratorBundle\Command\GeneratorPluginCommand;
+use Newscoop\PluginGeneratorBundle\Generator\BundleGenerator;
+
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\Output;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+use Sensio\Bundle\GeneratorBundle\Manipulator\KernelManipulator;
+use Sensio\Bundle\GeneratorBundle\Manipulator\RoutingManipulator;
+use Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper;
+
+/**
+ * Generates bundles.
+ *
+ * @author Mark Lewis <mark.lewis@sourcefabric.org>
+ */
+class GeneratePluginBundleCommand extends GeneratorPluginCommand
+{
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        $this
+            ->setDefinition(array(
+                new InputOption('vendor', '', InputOption::VALUE_REQUIRED, 'The vendor of the plugin to create'),
+                new InputOption('namespace', '', InputOption::VALUE_REQUIRED, 'The namespace of the plugin to create'),
+                new InputOption('dir', '', InputOption::VALUE_REQUIRED, 'The directory where to create the bundle'),
+                new InputOption('bundle-name', '', InputOption::VALUE_REQUIRED, 'The required bundle name'),
+                new InputOption('plugin-name', '', InputOption::VALUE_REQUIRED, 'The required plugin name'),
+                new InputOption('format', '', InputOption::VALUE_REQUIRED, 'Use the format for configuration files (php, xml, yml, or annotation)'),
+                new InputOption('structure', '', InputOption::VALUE_NONE, 'Whether to generate the whole directory structure'),
+                new InputOption('admin', '', InputOption::VALUE_NONE, 'Whether to generate a plugin admin structure'),
+                new InputOption('zip', '', InputOption::VALUE_NONE, 'Whether to generate a private plugin zip archive'),
+            ))
+            ->setDescription('Generates a Newscoop Plugin bundle')
+            ->setHelp(<<<EOT
+The <info>generate:plugin-bundle</info> command helps you generates new Newscoop Plugin bundles.
+
+By default, the command interacts with the developer to tweak the generation.
+Any passed option will be used as a default value for the interaction
+(<comment>--namespace</comment> is the only one needed if you follow the
+conventions):
+
+<info>php app/console generate:plugin-bundle --plugin-name=NewFeature</info>
+
+If you want to disable any user interaction, use <comment>--no-interaction</comment> but don't forget to pass all needed options:
+
+<info>php app/console generate:plugin-bundle --plugin-name=NewFeature --dir=src [--bundle-name=...] --no-interaction</info>
+
+Note that the plugin-name should NOT include the words "Plugin" or "Bundle".
+EOT
+            )
+            ->setName('generate:plugin-bundle')
+        ;
+    }
+
+    /**
+     * @see Command
+     *
+     * @throws \InvalidArgumentException When namespace doesn't end with Bundle
+     * @throws \RuntimeException         When bundle can't be executed
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $dialog = $this->getDialogHelper();
+
+        if ($input->isInteractive()) {
+            if (!$dialog->askConfirmation($output, $dialog->getQuestion('Do you confirm generation', 'yes', '?'), true)) {
+                $output->writeln('<error>Command aborted</error>');
+
+                return 1;
+            }
+        }
+
+        foreach (array('plugin-name', 'namespace', 'dir') as $option) {
+            if (null === $input->getOption($option)) {
+                throw new \RuntimeException(sprintf('The "%s" option must be provided.', $option));
+            }
+        }
+
+        // validate the namespace
+        $vendor = Validators::validateVendor($input->getOption('vendor'));
+        $pluginName = Validators::validatePluginName($input->getOption('plugin-name'));
+        $namespace = Validators::validateBundleNamespace($input->getOption('namespace'), false);
+        if (!$bundle = $input->getOption('bundle-name')) {
+            $bundle = strtr($namespace, array('\\' => ''));
+        }
+        $bundle = Validators::validateBundleName($bundle);
+        $dir = Validators::validateTargetDir($input->getOption('dir'));
+        if (null === $input->getOption('format')) {
+            $input->setOption('format', 'annotation');
+        }
+        $format = Validators::validateFormat($input->getOption('format'));
+        $structure = $input->getOption('structure');
+        $admin = $input->getOption('admin');
+        $zip = $input->getOption('zip');
+
+        $dialog->writeSection($output, 'Bundle generation');
+
+        if (!$this->getContainer()->get('filesystem')->isAbsolutePath($dir)) {
+            $dir = getcwd().'/'.$dir;
+        }
+
+        $generator = $this->getGenerator();
+        $generator->generate(
+            $vendor,
+            $pluginName, 
+            $namespace, 
+            $bundle, 
+            $dir, 
+            $format, 
+            $structure, 
+            $admin, 
+            $zip
+        );
+
+        $output->writeln('Generating the bundle code: <info>OK</info>');
+
+        $errors = array();
+
+        $dialog->writeGeneratorSummary($output, $errors);
+
+        $output->writeln('You must run the plugin install command manually: <comment>php application/console plugins:install '.strtolower($vendor).'/'.strtolower($pluginName).'-plugin-bundle</comment>');
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $dialog = $this->getDialogHelper();
+        $dialog->writeSection($output, 'Welcome to the Newscoop Plugin bundle generator');
+
+        // vendor 
+        $vendor = null;
+        try {
+            // validate the plugin name
+            $vendor = $input->getOption('vendor') ? Validators::validateVendor($input->getOption('vendor')) : null;
+        } catch (\Exception $error) {
+            $output->writeln($dialog->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
+        }
+
+        if (null === $vendor) {
+            $output->writeln(array(
+                '',
+                'Your application code must be written in <comment>bundles</comment>. This command helps',
+                'you generate the bundle name and namespace easily.',
+                '',
+                'Each bundle is hosted under a namespace (like <comment>Google/YoutubePluginBundle</comment>).',
+                'The vendor should be a "vendor" name like your company name',
+                '(Google in the above example)',
+                'It should be camel cased with no spaces, and should NOT contain the words "Plugin"',
+                'or "Bundle" (these will be appended automatically)',
+                '',
+            ));
+
+            $acceptedVendor = false;
+            while (!$acceptedVendor) {
+                $vendor = $dialog->askAndValidate(
+                    $output,
+                    $dialog->getQuestion('Vendor', $input->getOption('vendor')),
+                    function ($vendor) use ($dialog, $output) {
+                        return Validators::validateVendor($vendor);
+                    },
+                    false,
+                    $input->getOption('vendor')
+                );
+
+                // mark as accepted, unless they want to try again below
+                $acceptedVendor = true;
+            }
+            $input->setOption('vendor', $vendor);
+        }
+
+        // pluginName
+        $pluginName = null;
+        try {
+            // validate the plugin name
+            $pluginName = $input->getOption('plugin-name') ? Validators::validatePluginName($input->getOption('plugin-name')) : null;
+        } catch (\Exception $error) {
+            $output->writeln($dialog->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
+        }
+
+        if (null === $pluginName) {
+            $output->writeln(array(
+                '',
+                'Your application code must be written in <comment>bundles</comment>. This command helps',
+                'you generate the bundle name and namespace easily.',
+                '',
+                'Each bundle is hosted under a namespace (like <comment>Newscoop/YoutubePluginBundle</comment>).',
+                'The plugin name should be a project name, product name, or your client name.',
+                'It should be camel cased with no spaces, and should NOT contain the words "Plugin"',
+                'or "Bundle" (these will be appended automatically)',
+                '',
+            ));
+
+            $acceptedPluginName = false;
+            while (!$acceptedPluginName) {
+                $pluginName = $dialog->askAndValidate(
+                    $output,
+                    $dialog->getQuestion('Plugin name', $input->getOption('plugin-name')),
+                    function ($pluginName) use ($dialog, $output) {
+                        return Validators::validatePluginName($pluginName);
+                    },
+                    false,
+                    $input->getOption('plugin-name')
+                );
+
+                // mark as accepted, unless they want to try again below
+                $acceptedPluginName = true;
+            }
+            $input->setOption('plugin-name', $pluginName);
+        }
+
+        // namespace
+        $namespace = ucwords($vendor) ."/" . $pluginName . 'PluginBundle';
+        $input->setOption('namespace', $namespace);
+
+        // bundle name
+        $bundle = ucwords($vendor) . $pluginName . 'PluginBundle';
+        $input->setOption('bundle-name', $bundle);
+
+        // target dir
+        $dir = null;
+        try {
+            $dir = $input->getOption('dir') ? Validators::validateTargetDir($input->getOption('dir')) : null;
+        } catch (\Exception $error) {
+            $output->writeln($dialog->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
+        }
+
+        if (null === $dir) {
+            $dir = dirname($this->getContainer()->getParameter('kernel.root_dir')).'/plugins/'.ucwords($vendor);
+
+            $output->writeln(array(
+                '',
+                'The bundle can be generated anywhere. The suggested default directory uses',
+                'the plugin directory for this Newscoop instance.',
+                '',
+            ));
+            $dir = $dialog->askAndValidate($output, $dialog->getQuestion('Target directory', $dir), function ($dir) use ($bundle, $namespace) { return Validators::validateTargetDir($dir); }, false, $dir);
+            $input->setOption('dir', $dir);
+        }
+
+        // format
+        $format = null;
+        try {
+            $format = $input->getOption('format') ? Validators::validateFormat($input->getOption('format')) : null;
+        } catch (\Exception $error) {
+            $output->writeln($dialog->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
+        }
+
+        if (null === $format) {
+            $output->writeln(array(
+                '',
+                'Determine the format to use for the generated configuration.',
+                '',
+            ));
+            $format = $dialog->askAndValidate($output, $dialog->getQuestion('Configuration format (yml, xml, php, or annotation)', $input->getOption('format')), array('Newscoop\PluginGeneratorBundle\Command\Validators', 'validateFormat'), false, $input->getOption('format'));
+            $input->setOption('format', $format);
+        }
+
+        // optional files to generate
+        $output->writeln(array(
+            '',
+            'To help you get started faster, the command can generate some',
+            'code snippets for you.',
+            '',
+        ));
+
+        $structure = $input->getOption('structure');
+        if (!$structure && $dialog->askConfirmation($output, $dialog->getQuestion('Do you want to generate the whole directory structure', 'no', '?'), false)) {
+            $structure = true;
+        }
+        $input->setOption('structure', $structure);
+
+        $admin = $input->getOption('admin');
+        if (!$admin && $dialog->askConfirmation($output, $dialog->getQuestion('Do you want to generate an Admin structure', 'no', '?'), false)) {
+            $admin = true;
+        }
+        $input->setOption('admin', $admin);
+
+        $zip = $input->getOption('zip');
+        if (!$zip && $dialog->askConfirmation($output, $dialog->getQuestion('Do you want to generate a private plugin zip', 'no', '?'), false)) {
+            $zip = true;
+        }
+        $input->setOption('zip', $zip);
+
+        // summary
+        $output->writeln(array(
+            '',
+            $this->getHelper('formatter')->formatBlock('Summary before generation', 'bg=blue;fg=white', true),
+            '',
+            sprintf("You are going to generate a \"<info>%s\\%s</info>\" bundle\nin \"<info>%s</info>\" using the \"<info>%s</info>\" format.", $namespace, $bundle, $dir, $format),
+            '',
+        ));
+    }
+
+    protected function createGenerator()
+    {
+        return new BundleGenerator($this->getContainer());
+    }
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Command/GeneratorPluginCommand.php
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Command/GeneratorPluginCommand.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * This file is part of the NewscooPluginGeneratorBundle package.
+ *
+ * (c) Mark Lewis <mark.lewis@sourcefabric.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Newscoop\PluginGeneratorBundle\Command;
+
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+
+use Sensio\Bundle\GeneratorBundle\Generator\Generator;
+use Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper;
+/**
+ * Base class for generator commands.
+ *
+ * @author Mark Lewis <mark.lewis@sourcefabric.org>
+ */
+abstract class GeneratorPluginCommand extends ContainerAwareCommand
+{
+    private $generator;
+    // only useful for unit tests
+    public function setGenerator(Generator $generator)
+    {
+        $this->generator = $generator;
+    }
+    abstract protected function createGenerator();
+    protected function getGenerator(BundleInterface $bundle = null)
+    {
+        if (null === $this->generator) {
+            $this->generator = $this->createGenerator();
+            $this->generator->setSkeletonDirs($this->getSkeletonDirs($bundle));
+        }
+        return $this->generator;
+    }
+    protected function getSkeletonDirs(BundleInterface $bundle = null)
+    {
+        $skeletonDirs = array();
+        if (isset($bundle) && is_dir($dir = $bundle->getPath().'/Resources/SensioGeneratorBundle/skeleton')) {
+            $skeletonDirs[] = $dir;
+        }
+        if (is_dir($dir = $this->getContainer()->get('kernel')->getRootdir().'/Resources/SensioGeneratorBundle/skeleton')) {
+            $skeletonDirs[] = $dir;
+        }
+        $skeletonDirs[] = __DIR__.'/../Resources/skeleton';
+        $skeletonDirs[] = __DIR__.'/../Resources';
+        return $skeletonDirs;
+    }
+    protected function getDialogHelper()
+    {
+        $dialog = $this->getHelperSet()->get('dialog');
+        if (!$dialog || get_class($dialog) !== 'Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper') {
+            $this->getHelperSet()->set($dialog = new DialogHelper());
+        }
+        return $dialog;
+    }
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Command/Validators.php
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Command/Validators.php
@@ -1,0 +1,206 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Newscoop\PluginGeneratorBundle\Command;
+
+/**
+ * Validator functions.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class Validators
+{
+    public static function validateVendor($vendor)
+    {
+        if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $vendor)) {
+            throw new \InvalidArgumentException('The vendor contains invalid characters.');
+        }
+
+        return $vendor;
+    }
+
+    public static function validatePluginName($pluginName)
+    {
+        if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $pluginName)) {
+            throw new \InvalidArgumentException('The plugin name contains invalid characters.');
+        }
+
+        return $pluginName;
+    }
+
+    public static function validateBundleNamespace($namespace, $requireVendorNamespace = true)
+    {
+        if (!preg_match('/Bundle$/', $namespace)) {
+            throw new \InvalidArgumentException('The namespace must end with Bundle.');
+        }
+
+        $namespace = strtr($namespace, '/', '\\');
+        if (!preg_match('/^(?:[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*\\\?)+$/', $namespace)) {
+            throw new \InvalidArgumentException('The namespace contains invalid characters.');
+        }
+
+        // validate reserved keywords
+        $reserved = self::getReservedWords();
+        foreach (explode('\\', $namespace) as $word) {
+            if (in_array(strtolower($word), $reserved)) {
+                throw new \InvalidArgumentException(sprintf('The namespace cannot contain PHP reserved words ("%s").', $word));
+            }
+        }
+
+        // validate that the namespace is at least one level deep
+        if ($requireVendorNamespace && false === strpos($namespace, '\\')) {
+            // language is (almost) duplicated in GenerateBundleCommand
+            $msg = array();
+            $msg[] = sprintf('The namespace must contain a vendor namespace (e.g. "VendorName\%s" instead of simply "%s").', $namespace, $namespace);
+            $msg[] = 'If you\'ve specified a vendor namespace, did you forget to surround it with quotes (init:bundle "Acme\BlogBundle")?';
+
+            throw new \InvalidArgumentException(implode("\n\n", $msg));
+        }
+
+        return $namespace;
+    }
+
+    public static function validateBundleName($bundle)
+    {
+        if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $bundle)) {
+            throw new \InvalidArgumentException('The bundle name contains invalid characters.');
+        }
+
+        if (!preg_match('/Bundle$/', $bundle)) {
+            throw new \InvalidArgumentException('The bundle name must end with Bundle.');
+        }
+
+        return $bundle;
+    }
+
+    public static function validateControllerName($controller)
+    {
+        try {
+            self::validateEntityName($controller);
+        } catch (\InvalidArgumentException $e) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'The controller name must contain a : ("%s" given, expecting something like AcmeBlogBundle:Post)',
+                    $controller
+                )
+            );
+        }
+
+        return $controller;
+    }
+
+    public static function validateTargetDir($dir)
+    {
+        // add trailing / if necessary
+        return '/' === substr($dir, -1, 1) ? $dir : $dir.'/';
+    }
+
+    public static function validateFormat($format)
+    {
+        $format = strtolower($format);
+
+        if (!in_array($format, array('php', 'xml', 'yml', 'annotation'))) {
+            throw new \RuntimeException(sprintf('Format "%s" is not supported.', $format));
+        }
+
+        return $format;
+    }
+
+    public static function validateEntityName($entity)
+    {
+        if (false === strpos($entity, ':')) {
+            throw new \InvalidArgumentException(sprintf('The entity name must contain a : ("%s" given, expecting something like AcmeBlogBundle:Blog/Post)', $entity));
+        }
+
+        return $entity;
+    }
+
+    public static function getReservedWords()
+    {
+        return array(
+            'abstract',
+            'and',
+            'array',
+            'as',
+            'break',
+            'callable',
+            'case',
+            'catch',
+            'class',
+            'clone',
+            'const',
+            'continue',
+            'declare',
+            'default',
+            'do',
+            'else',
+            'elseif',
+            'enddeclare',
+            'endfor',
+            'endforeach',
+            'endif',
+            'endswitch',
+            'endwhile',
+            'extends',
+            'final',
+            'finally',
+            'for',
+            'foreach',
+            'function',
+            'global',
+            'goto',
+            'if',
+            'implements',
+            'interface',
+            'instanceof',
+            'insteadof',
+            'namespace',
+            'new',
+            'or',
+            'private',
+            'protected',
+            'public',
+            'static',
+            'switch',
+            'throw',
+            'trait',
+            'try',
+            'use',
+            'var',
+            'while',
+            'xor',
+            'yield',
+            '__CLASS__',
+            '__DIR__',
+            '__FILE__',
+            '__LINE__',
+            '__FUNCTION__',
+            '__METHOD__',
+            '__NAMESPACE__',
+            '__TRAIT__',
+            '__halt_compiler',
+            'die',
+            'echo',
+            'empty',
+            'exit',
+            'eval',
+            'include',
+            'include_once',
+            'isset',
+            'list',
+            'require',
+            'require_once',
+            'return',
+            'print',
+            'unset',
+        );
+    }
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/DependencyInjection/Configuration.php
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Newscoop\PluginGeneratorBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * This is the class that validates and merges configuration from your app/config files
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+
+        // Here you should define the parameters that are allowed to
+        // configure your bundle. See the documentation linked above for
+        // more information on that topic.
+
+        return $treeBuilder;
+    }
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/DependencyInjection/NewscoopPluginGeneratorExtension.php
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/DependencyInjection/NewscoopPluginGeneratorExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Newscoop\PluginGeneratorBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+/**
+ * This is the class that loads and manages your bundle configuration
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
+ */
+class NewscoopPluginGeneratorExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+    }
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Generator/BundleGenerator.php
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Generator/BundleGenerator.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Newscoop\PluginGeneratorBundle\Generator;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\DependencyInjection\Container;
+
+/**
+ * Generates a bundle.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class BundleGenerator extends Generator
+{
+    private $filesystem;
+
+    protected $container;
+
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+        $this->filesystem = $this->container->get('filesystem');
+    }
+
+    public function generate($vendor, $pluginName, $namespace, $bundle, $dir, $format, $structure, $admin, $zip)
+    {
+        $dir .= '/'.strtr($namespace, array(ucwords($vendor) => '', '\\' => '', '\/' => ''));
+        if (file_exists($dir)) {
+            if (!is_dir($dir)) {
+                throw new \RuntimeException(sprintf('Unable to generate the bundle as the target directory "%s" exists but is a file.', realpath($dir)));
+            }
+            $files = scandir($dir);
+            if ($files != array('.', '..')) {
+                throw new \RuntimeException(sprintf('Unable to generate the bundle as the target directory "%s" is not empty.', realpath($dir)));
+            }
+            if (!is_writable($dir)) {
+                throw new \RuntimeException(sprintf('Unable to generate the bundle as the target directory "%s" is not writable.', realpath($dir)));
+            }
+        }
+
+        $basename = substr($bundle, 0, -6);
+        $parameters = array(
+            'vendor' => $vendor,
+            'admin' => $admin,
+            'pluginName' => $pluginName,
+            'namespace' => $namespace,
+            'bundle'    => $bundle,
+            'format'    => $format,
+            'bundle_basename' => $basename,
+            'extension_alias' => Container::underscore($basename),
+        );
+
+        $this->renderFile('bundle/composer.json.twig', $dir.'/composer.json', $parameters);
+        $this->renderFile('bundle/Bundle.php.twig', $dir.'/'.$bundle.'.php', $parameters);
+        $this->renderFile('bundle/Extension.php.twig', $dir.'/DependencyInjection/'.$basename.'Extension.php', $parameters);
+        $this->renderFile('bundle/Configuration.php.twig', $dir.'/DependencyInjection/Configuration.php', $parameters);
+        $this->renderFile('bundle/LifecycleSubscriber.php.twig', $dir.'/EventListener/LifecycleSubscriber.php', $parameters);
+        $this->renderFile('bundle/DefaultController.php.twig', $dir.'/Controller/'.$pluginName.'Controller.php', $parameters);
+        $this->renderFile('bundle/DefaultControllerTest.php.twig', $dir.'/Tests/Controller/'.$pluginName.'ControllerTest.php', $parameters);
+        $this->renderFile('bundle/index.html.twig.twig', $dir.'/Resources/views/'.$pluginName.'/index.html.twig', $parameters);
+
+        if ('xml' === $format || 'annotation' === $format) {
+            $this->renderFile('bundle/services.xml.twig', $dir.'/Resources/config/services.xml', $parameters);
+        } else {
+            $this->renderFile('bundle/services.'.$format.'.twig', $dir.'/Resources/config/services.'.$format, $parameters);
+        }
+
+        if ('annotation' != $format) {
+            $this->renderFile('bundle/routing.'.$format.'.twig', $dir.'/Resources/config/routing.'.$format, $parameters);
+        }
+
+        if ($admin) {
+            $this->renderFile('bundle/ConfigurationMenuListener.php.twig', $dir.'/EventListener/ConfigurationMenuListener.php', $parameters);
+            $this->renderFile('bundle/AdminController.php.twig', $dir.'/Controller/AdminController.php', $parameters);
+            $this->renderFile('bundle/admin.index.html.twig.twig', $dir.'/Resources/views/Admin/index.html.twig', $parameters);
+        }
+
+        if ($structure) {
+            $this->renderFile('bundle/messages.fr.xlf', $dir.'/Resources/translations/messages.fr.xlf', $parameters);
+
+            $this->filesystem->mkdir($dir.'/Resources/doc');
+            $this->filesystem->touch($dir.'/Resources/doc/index.rst');
+            $this->filesystem->mkdir($dir.'/Resources/translations');
+            $this->filesystem->mkdir($dir.'/Resources/public/css');
+            $this->filesystem->mkdir($dir.'/Resources/public/images');
+            $this->filesystem->mkdir($dir.'/Resources/public/js');
+        }
+
+        if ($zip) {
+            $zipFilePath = dirname($this->container->getParameter('kernel.root_dir')).'/plugins/private_plugins/' . $vendor . $pluginName .'PluginBundle.zip';
+            $zipFile = new \ZipArchive();
+            // open archive
+            if ($zipFile->open($zipFilePath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE) !== TRUE) {
+                throw new \RuntimeException(sprintf('Could not create zip archive "%s".', realpath($zipFilePath)));
+            }
+
+            $dirPathLength = strlen($dir);
+            // initialize an iterator
+            // pass it the directory to be processed
+            $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir));
+            // iterate over the directory
+            // add each file found to the archive
+            $addedDirs = array('/');
+            foreach ($iterator as $key=>$value) {
+                $fname = substr($key, $dirPathLength);
+                if (strlen($fname) > 0 && !in_array(basename($fname), array('.', '..')) ) {
+                    if ( !in_array(dirname($fname),$addedDirs) ) {
+                        if (!$zipFile->addEmptyDir(dirname($fname))) {
+                            return false;
+                        }
+                        $addedDirs[]=dirname($fname);
+                    }
+                    if (!$zipFile->addFile(realpath($key), ltrim($fname, '/'))) {
+                        throw new \RuntimeException(sprintf('Could not add file to zip archive "%s".', $key));
+                    }
+                }
+            }
+
+            // close and save archive
+            if (!$zipFile->close()) {
+                throw new \RuntimeException(sprintf('Could not save zip archive "%s".', realpath($zipFilePath)));
+            }
+        }
+    }
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Generator/Generator.php
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Generator/Generator.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Newscoop\PluginGeneratorBundle\Generator;
+
+/**
+ * Generator is the base class for all generators.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class Generator
+{
+    private $skeletonDirs;
+
+    /**
+     * Sets an array of directories to look for templates.
+     *
+     * The directories must be sorted from the most specific to the most
+     * directory.
+     *
+     * @param array $skeletonDirs An array of skeleton dirs
+     */
+    public function setSkeletonDirs($skeletonDirs)
+    {
+        $this->skeletonDirs = is_array($skeletonDirs) ? $skeletonDirs : array($skeletonDirs);
+    }
+
+    protected function render($template, $parameters)
+    {
+        $twig = $this->getTwigEnvironment();
+
+        return $twig->render($template, $parameters);
+    }
+
+    /**
+     * Get the twig environment that will render skeletons
+     * @return \Twig_Environment
+     */
+    protected function getTwigEnvironment()
+    {
+        return new \Twig_Environment(new \Twig_Loader_Filesystem($this->skeletonDirs), array(
+            'debug'            => true,
+            'cache'            => false,
+            'strict_variables' => true,
+            'autoescape'       => false,
+        ));
+    }
+
+    protected function renderFile($template, $target, $parameters)
+    {
+        if (!is_dir(dirname($target))) {
+            mkdir(dirname($target), 0777, true);
+        }
+
+        return file_put_contents($target, $this->render($template, $parameters));
+    }
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/NewscoopPluginGeneratorBundle.php
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/NewscoopPluginGeneratorBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Newscoop\PluginGeneratorBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class NewscoopPluginGeneratorBundle extends Bundle
+{
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/config/routing.yml
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/config/routing.yml
@@ -1,0 +1,3 @@
+newscoop_plugin_generator_homepage:
+    path:     /hello/{name}
+    defaults: { _controller: NewscoopPluginGeneratorBundle:Default:index }

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/config/services.yml
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/config/services.yml
@@ -1,0 +1,4 @@
+services:
+#    newscoop_plugin_generator.example:
+#        class: Newscoop\PluginGeneratorBundle\Example
+#        arguments: [@service_id, "plain_value", %parameter%]

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/AdminController.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/AdminController.php.twig
@@ -1,0 +1,30 @@
+<?php
+
+namespace {{ namespace }}\Controller;
+
+{% block use_statements %}
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+{% endblock use_statements %}
+
+{% block class_definition %}
+class AdminController extends Controller
+{% endblock class_definition %}
+{
+{% block class_body %}
+    /**
+     * @Route("/admin/{{ pluginName | lower }}")
+     * @Template()
+     */
+    public function indexAction(Request $request)
+    {
+        return array('name' => "admin");
+
+    }
+{% endblock class_body %}
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/Bundle.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/Bundle.php.twig
@@ -1,0 +1,15 @@
+<?php
+
+namespace {{ namespace }};
+
+{% block use_statements %}
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+{% endblock use_statements %}
+
+{% block class_definition %}
+class {{ bundle }} extends Bundle
+{% endblock class_definition %}
+{
+{% block class_body %}
+{% endblock class_body %}
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/Configuration.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/Configuration.php.twig
@@ -1,0 +1,37 @@
+<?php
+
+namespace {{ namespace }}\DependencyInjection;
+
+{% block use_statements %}
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+{% endblock use_statements %}
+
+/**
+{% block phpdoc_class_header %}
+ * This is the class that validates and merges configuration from your app/config files
+{% endblock phpdoc_class_header %}
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ */
+{% block class_definition %}
+class Configuration implements ConfigurationInterface
+{% endblock class_definition %}
+{
+{% block class_body %}
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('{{ extension_alias }}');
+
+        // Here you should define the parameters that are allowed to
+        // configure your bundle. See the documentation linked above for
+        // more information on that topic.
+
+        return $treeBuilder;
+    }
+{% endblock class_body %}
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/ConfigurationMenuListener.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/ConfigurationMenuListener.php.twig
@@ -1,0 +1,37 @@
+<?php
+
+namespace {{ namespace }}\EventListener;
+
+{% block use_statements %}
+use Newscoop\NewscoopBundle\Event\ConfigureMenuEvent;
+use Symfony\Component\Translation\Translator;
+{% endblock use_statements %}
+
+{% block class_definition %}
+class ConfigureMenuListener
+{% endblock class_definition %}
+{
+{% block class_body %}
+    protected $translator;
+
+    /**
+     * @param Translator $translator
+     */
+    public function __construct(Translator $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
+     * @param \Newscoop\NewscoopBundle\Event\ConfigureMenuEvent $event
+     */
+    public function onMenuConfigure(ConfigureMenuEvent $event)
+    {
+        $menu = $event->getMenu();
+        $menu[$this->translator->trans('Plugins')]->addChild(
+            '{{ pluginName }} Plugin',
+            array('uri' => $event->getRouter()->generate('{{ vendor | lower }}_{{ pluginName | lower }}plugin_admin_index'))
+        );
+    }
+{% endblock class_body %}
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/DefaultController.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/DefaultController.php.twig
@@ -1,0 +1,30 @@
+<?php
+
+namespace {{ namespace }}\Controller;
+
+{% block use_statements %}
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response; 
+{% endblock use_statements %}
+
+/**
+ * Route("/{{ pluginName | lower }}")
+ */ 
+{% block class_definition %}
+class {{ pluginName }}Controller extends Controller
+{% endblock class_definition %}
+{
+{% block class_body %}
+    /**
+     * @Route("/{{ pluginName | lower }}/{name}")
+     * @Template()
+     */
+    public function indexAction($name)
+    {
+        return array('name' => $name);
+    }
+{% endblock class_body %}
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/DefaultControllerTest.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/DefaultControllerTest.php.twig
@@ -1,0 +1,23 @@
+<?php
+
+namespace {{ namespace }}\Tests\Controller;
+
+{% block use_statements %}
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+{% endblock use_statements %}
+
+{% block class_definition %}
+class {{ pluginName }}ControllerTest extends WebTestCase
+{% endblock class_definition %}
+{
+{% block class_body %}
+    public function testIndex()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/{{ pluginName | lower }}/Tester');
+
+        $this->assertTrue($crawler->filter('html:contains("Hello Tester")')->count() > 0);
+    }
+{% endblock class_body %}
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/Extension.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/Extension.php.twig
@@ -1,0 +1,45 @@
+<?php
+
+namespace {{ namespace }}\DependencyInjection;
+
+{% block use_statements %}
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+{% endblock use_statements %}
+
+/**
+{% block phpdoc_class_header %}
+ * This is the class that loads and manages your bundle configuration
+{% endblock phpdoc_class_header %}
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
+ */
+{% block class_definition %}
+class {{ bundle_basename }}Extension extends Extension
+{% endblock class_definition %}
+{
+{% block class_body %}
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        {% if format == 'yml' -%}
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+        {%- elseif format == 'xml' or format == 'annotation' -%}
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.xml');
+        {%- elseif format == 'php' -%}
+        $loader = new Loader\PhpFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.php');
+        {%- endif %}
+
+    }
+{% endblock class_body %}
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/LifecycleSubscriber.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/LifecycleSubscriber.php.twig
@@ -1,0 +1,102 @@
+<?php
+
+namespace {{ namespace }}\EventListener;
+
+{% block use_statements %}
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Newscoop\EventDispatcher\Events\GenericEvent;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+{% endblock use_statements %}
+
+/**
+ * Event lifecycle management
+ */
+
+{% block class_definition %}
+class LifecycleSubscriber implements EventSubscriberInterface
+{% endblock class_definition %}
+{
+{% block class_body %}
+    private $container;
+   
+    protected $em;
+ 
+    protected $scheduler;
+
+    protected $cronjobs;
+
+    protected $preferences;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $appDirectory = realpath(__DIR__.'/../../../../application/console');
+        $this->container = $container;
+        $this->em = $this->container->get('em');
+        $this->scheduler = $this->container->get('newscoop.scheduler');
+        $this->preferences = $this->container->get('system_preferences_service');
+        $this->cronjobs = array();
+    }
+
+    public function install(GenericEvent $event)
+    {
+        $tool = new \Doctrine\ORM\Tools\SchemaTool($this->em);
+        $tool->updateSchema($this->getClasses(), true);
+        
+        // Set default preferences here
+
+        // Generate proxies for entities
+        $this->em->getProxyFactory()->generateProxyClasses($this->getClasses(), __DIR__ . '/../../../../library/Proxy');
+        $this->addJobs();
+    }
+
+    public function update(GenericEvent $event)
+    {
+        $tool = new \Doctrine\ORM\Tools\SchemaTool($this->em);
+        $tool->updateSchema($this->getClasses(), true);
+
+        // Generate proxies for entities
+        $this->em->getProxyFactory()->generateProxyClasses($this->getClasses(), __DIR__ . '/../../../../library/Proxy');
+    }
+
+    public function remove(GenericEvent $event)
+    {
+        $tool = new \Doctrine\ORM\Tools\SchemaTool($this->em);
+        $tool->dropSchema($this->getClasses(), true);
+        $this->removeJobs();
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            'plugin.install.newscoop_{{ pluginName | lower }}_plugin_bundle' => array('install', 1),
+            'plugin.update.newscoop_{{ pluginName | lower }}_plugin_bundle' => array('update', 1),
+            'plugin.remove.newscoop_{{ pluginName | lower }}_plugin_bundle' => array('remove', 1),
+        );
+    }
+
+    /**
+     * Add plugin cron jobs
+     */
+    private function addJobs()
+    {
+        foreach ($this->cronjobs as $jobName => $jobConfig) {
+            $this->scheduler->registerJob($jobName, $jobConfig);
+        }
+    }
+
+    /**
+     * Remove plugin cron jobs
+     */
+    private function removeJobs()
+    {
+        foreach ($this->cronjobs as $jobName => $jobConfig) {
+            $this->scheduler->removeJob($jobName, $jobConfig);
+        }
+    }
+
+    private function getClasses()
+    {
+        return array();
+    }
+{% endblock class_body %}
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/admin.index.html.twig.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/admin.index.html.twig.twig
@@ -1,0 +1,23 @@
+{% raw %}
+{% extends 'NewscoopNewscoopBundle::admin_layout.html.twig' %}
+
+{% block admin_title %}{{ parent() }} - {% endraw %}{{ pluginName }}{% raw %} Admin{% endblock %}
+{% block admin_page_title_content %}{% endraw %}{{ pluginName }}{% raw %} Admin{% endblock %}
+
+{% block admin_stylesheets %}
+<link rel="stylesheet" href="{{ asset('/bundles/newscoopnewscoop/css/jquery.dynatable.css') }}">
+{% endblock %}
+
+{% block admin_scripts %}
+<script src="{{ asset('/js/select2/select2.js') }}"></script>
+<script src="{{ asset('/bundles/newscoopnewscoop/js/jquery.dynatable.js') }}"></script>
+{% endblock %}
+
+{% block admin_content %}
+{% endraw %}
+
+<div class="plugin-container">
+  <p>Hi, {% raw %}{{ name }}{% endraw %}</p>
+</div>
+
+{% raw %}{% endblock %}{% endraw %}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/composer.json.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/composer.json.twig
@@ -1,0 +1,23 @@
+{
+    "name": "{{ vendor | lower }}/{{ pluginName | lower }}-plugin-bundle",
+    "description": "{{ pluginName }} plugin for Newscoop",
+    "keywords": ["{{ vendor }}", "{{ pluginName | lower }}"],
+    "version": "0.0.1",
+    "type": "newscoop-plugin",
+    "license": "GPL-3.0",
+    "authors": [
+        {
+            "name": "Your Name",
+            "email": "your.name@domain.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.3",
+        "newscoop/plugins-installer": ">=v0.2"
+    },
+    "autoload": {
+        "psr-0": { "{{ vendor | capitalize }}\\{{ pluginName }}PluginBundle\\{{ pluginName }}PluginBundle": "" }
+    },
+    "target-dir": "{{ vendor | capitalize }}/{{ pluginName }}PluginBundle",
+    "minimum-stability": "dev"
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/index.html.twig.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/index.html.twig.twig
@@ -1,0 +1,1 @@
+Hello {% raw %}{{ name }}{% endraw %}!

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/messages.fr.xlf
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/messages.fr.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>Symfony2 is great</source>
+                <target>J'aime Symfony2</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/routing.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/routing.php.twig
@@ -1,0 +1,20 @@
+<?php
+
+{% block use_statements %}
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\Route;
+{% endblock use_statements %}
+
+{% block definition %}
+$collection = new RouteCollection();
+{% endblock definition %}
+
+{% block body %}
+$collection->add('{{ extension_alias }}', new Route('/{{ pluginName | lower }}/{name}', array(
+    '_controller' => '{{ bundle }}:Default:index',
+)));
+{% endblock body %}
+
+{% block return %}
+return $collection;
+{% endblock return %}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/routing.xml.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/routing.xml.twig
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+{% block body %}
+    <route id="{{ extension_alias }}" path="/hello/{name}">
+        <default key="_controller">{{ bundle }}:Default:index</default>
+    </route>
+{% endblock body %}
+</routes>

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/routing.yml.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/routing.yml.twig
@@ -1,0 +1,4 @@
+{{ extension_alias }}:
+    resource: "@{{ bundle }}/Controller"
+    type:     annotation
+    prefix:   /

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/services.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/services.php.twig
@@ -1,0 +1,25 @@
+<?php
+
+{% block use_statements %}
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Parameter;
+{% endblock use_statements %}
+
+/*
+
+{% block services %}
+$container->setDefinition(
+    '{{ extension_alias }}.example',
+    new Definition(
+        '{{ namespace }}\Example',
+        array(
+            new Reference('service_id'),
+            "plain_value",
+            new Parameter('parameter_name'),
+        )
+    )
+);
+{% endblock services %}
+
+*/

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/services.xml.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/services.xml.twig
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <!--
+    <services>
+{% block services %}
+        <service id="{{ extension_alias }}.example" class="{{ namespace }}\Example">
+            <argument type="service" id="service_id" />
+            <argument>plain_value</argument>
+            <argument>%parameter_name%</argument>
+        </service>
+{% endblock services %}
+    </services>
+    -->
+</container>

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/services.yml.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/bundle/services.yml.twig
@@ -1,0 +1,19 @@
+services:
+{% block services %}
+    {{ vendor | lower }}_{{ pluginName | lower }}_plugin.lifecyclesubscriber:
+        class: {{ namespace }}\EventListener\LifecycleSubscriber
+        arguments:
+            - @service_container
+        tags:
+            - { name: kernel.event_subscriber}
+
+{% if admin == true %}
+    {{ vendor | lower }}_{{ pluginName | lower }}_plugin.configure_menu_listener:
+        class: {{ namespace }}\EventListener\ConfigureMenuListener
+        tags:
+          - { name: kernel.event_listener, event: newscoop_newscoop.menu_configure, method: onMenuConfigure }
+        arguments:
+            - @translator
+{% endif %}
+
+{% endblock services %}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/controller/Controller.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/controller/Controller.php.twig
@@ -1,0 +1,53 @@
+<?php
+
+namespace {{ namespace }}\Controller;
+
+{% block use_statements %}
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+{% if 'annotation' == format.routing -%}
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+{% endif %}
+{% endblock use_statements %}
+
+{% block class_definition %}
+class {{ controller }}Controller extends Controller
+{% endblock class_definition %}
+{
+{% block class_body %}
+{% for action in actions %}
+    {% if 'annotation' == format.routing -%}
+    /**
+     * @Route("{{ action.route }}")
+     {% if 'default' == action.template -%}
+     * @Template()
+     {% else -%}
+     * @Template("{{ action.template }}")
+     {% endif -%}
+     */
+    {% endif -%}
+    public function {{ action.name }}(
+        {%- if action.placeholders|length > 0 -%}
+            ${{- action.placeholders|join(', $') -}}
+        {%- endif -%})
+    {
+        {% if 'annotation' != format.routing -%}
+            {% if 'default' == action.template -%}
+            return $this->render('{{ bundle }}:{{ controller }}:{{ action.name|slice(0, -6) }}.html.{{ format.templating }}', array(
+                // ...
+            ));
+            {%- else -%}
+            return $this->render('{{ action.template }}', array(
+                // ...
+            ));
+            {%- endif %}
+        {%- else -%}
+            return array(
+                // ...
+            );
+        {%- endif %}
+    }
+
+{% endfor -%}
+{% endblock class_body %}
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/controller/ControllerTest.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/controller/ControllerTest.php.twig
@@ -1,0 +1,24 @@
+<?php
+
+namespace {{ namespace }}\Tests\Controller;
+
+{% block use_statements %}
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+{% endblock use_statements %}
+
+{% block class_definition %}
+class {{ controller }}ControllerTest extends WebTestCase
+{% endblock class_definition %}
+{
+{% block class_body %}
+{% for action in actions %}
+    public function test{{ action.basename|capitalize }}()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '{{ action.route }}');
+    }
+
+{% endfor -%}
+{% endblock class_body %}
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/controller/Template.html.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/controller/Template.html.php.twig
@@ -1,0 +1,7 @@
+<?php $view->extend('::base.html.twig') ?>
+
+<?php $view['slots']->set('title', '{{ bundle }}:{{ controller }}:{{ action.basename }}') ?>
+
+<?php $view['slots']->start('body') ?>
+    <h1>Welcome to the {{ controller }}:{{ action.basename }} page</h1>
+<?php $view['slots']->stop() ?>

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/controller/Template.html.twig.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/controller/Template.html.twig.twig
@@ -1,0 +1,9 @@
+{{ '{% extends "::base.html.twig" %}' }}
+
+{{ '{% block title %}' -}}
+{{ bundle }}:{{ controller }}:{{ action.basename }}
+{{- '{% endblock %}' }}
+
+{{ '{% block body %}' }}
+<h1>Welcome to the {{ controller }}:{{ action.basename }} page</h1>
+{{ '{% endblock %}' }}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/actions/create.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/actions/create.php.twig
@@ -1,0 +1,71 @@
+    /**
+{% block phpdoc_method_header %}
+     * Creates a new {{ entity }} entity.
+{% endblock phpdoc_method_header %}
+     *
+{% block phpdoc_method_annotations %}
+{% if 'annotation' == format %}
+     * @Route("/", name="{{ route_name_prefix }}_create")
+     * @Method("POST")
+     * @Template("{{ bundle }}:{{ entity }}:new.html.twig")
+{% endif %}
+{% endblock phpdoc_method_annotations %}
+     */
+{% block method_definition %}
+    public function createAction(Request $request)
+{% endblock method_definition %}
+    {
+{% block method_body %}
+        $entity = new {{ entity_class }}();
+        $form = $this->createCreateForm($entity);
+        $form->handleRequest($request);
+
+        if ($form->isValid()) {
+            $em = $this->getDoctrine()->getManager();
+            $em->persist($entity);
+            $em->flush();
+
+            {% if 'show' in actions -%}
+                return $this->redirect($this->generateUrl('{{ route_name_prefix }}_show', array('id' => $entity->getId())));
+            {%- else -%}
+                return $this->redirect($this->generateUrl('{{ route_name_prefix }}'));
+            {%- endif %}
+
+        }
+{% endblock method_body %}
+
+{% block method_return %}
+{% if 'annotation' == format %}
+        return array(
+            'entity' => $entity,
+            'form'   => $form->createView(),
+        );
+{% else %}
+        return $this->render('{{ bundle }}:{{ entity|replace({'\\': '/'}) }}:new.html.twig', array(
+            'entity' => $entity,
+            'form'   => $form->createView(),
+        ));
+{% endif %}
+{% endblock method_return %}
+    }
+
+{% block form %}
+    /**
+     * Creates a form to create a {{ entity }} entity.
+     *
+     * @param {{ entity_class }} $entity The entity
+     *
+     * @return \Symfony\Component\Form\Form The form
+     */
+    private function createCreateForm({{ entity_class }} $entity)
+    {
+        $form = $this->createForm(new {{ entity_class }}Type(), $entity, array(
+            'action' => $this->generateUrl('{{ route_name_prefix }}_create'),
+            'method' => 'POST',
+        ));
+
+        $form->add('submit', 'submit', array('label' => 'Create'));
+
+        return $form;
+    }
+{% endblock form %}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/actions/delete.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/actions/delete.php.twig
@@ -1,0 +1,56 @@
+    /**
+{% block phpdoc_method_header %}
+     * Deletes a {{ entity }} entity.
+{% endblock phpdoc_method_header %}
+     *
+{% block phpdoc_method_annotations %}
+{% if 'annotation' == format %}
+     * @Route("/{id}", name="{{ route_name_prefix }}_delete")
+     * @Method("DELETE")
+{% endif %}
+{% endblock phpdoc_method_annotations %}
+     */
+{% block method_definition %}
+    public function deleteAction(Request $request, $id)
+{% endblock method_definition %}
+    {
+{% block method_body %}
+        $form = $this->createDeleteForm($id);
+        $form->handleRequest($request);
+
+        if ($form->isValid()) {
+            $em = $this->getDoctrine()->getManager();
+            $entity = $em->getRepository('{{ bundle }}:{{ entity }}')->find($id);
+
+            if (!$entity) {
+                throw $this->createNotFoundException('Unable to find {{ entity }} entity.');
+            }
+
+            $em->remove($entity);
+            $em->flush();
+        }
+{% endblock method_body %}
+
+{% block method_return %}
+        return $this->redirect($this->generateUrl('{{ route_name_prefix }}'));
+{% endblock method_return %}
+    }
+
+{% block form %}
+    /**
+     * Creates a form to delete a {{ entity }} entity by id.
+     *
+     * @param mixed $id The entity id
+     *
+     * @return \Symfony\Component\Form\Form The form
+     */
+    private function createDeleteForm($id)
+    {
+        return $this->createFormBuilder()
+            ->setAction($this->generateUrl('{{ route_name_prefix }}_delete', array('id' => $id)))
+            ->setMethod('DELETE')
+            ->add('submit', 'submit', array('label' => 'Delete'))
+            ->getForm()
+        ;
+    }
+{% endblock form %}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/actions/edit.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/actions/edit.php.twig
@@ -1,0 +1,68 @@
+
+    /**
+{% block phpdoc_method_header %}
+     * Displays a form to edit an existing {{ entity }} entity.
+{% endblock phpdoc_method_header %}
+     *
+{% block phpdoc_method_annotations %}
+{% if 'annotation' == format %}
+     * @Route("/{id}/edit", name="{{ route_name_prefix }}_edit")
+     * @Method("GET")
+     * @Template()
+{% endif %}
+{% endblock phpdoc_method_annotations %}
+     */
+{% block method_definition %}
+    public function editAction($id)
+{% endblock method_definition %}
+    {
+{% block method_body %}
+        $em = $this->getDoctrine()->getManager();
+
+        $entity = $em->getRepository('{{ bundle }}:{{ entity }}')->find($id);
+
+        if (!$entity) {
+            throw $this->createNotFoundException('Unable to find {{ entity }} entity.');
+        }
+
+        $editForm = $this->createEditForm($entity);
+        $deleteForm = $this->createDeleteForm($id);
+{% endblock method_body %}
+
+{% block method_return %}
+{% if 'annotation' == format %}
+        return array(
+            'entity'      => $entity,
+            'edit_form'   => $editForm->createView(),
+            'delete_form' => $deleteForm->createView(),
+        );
+{% else %}
+        return $this->render('{{ bundle }}:{{ entity|replace({'\\': '/'}) }}:edit.html.twig', array(
+            'entity'      => $entity,
+            'edit_form'   => $editForm->createView(),
+            'delete_form' => $deleteForm->createView(),
+        ));
+{% endif %}
+{% endblock method_return %}
+    }
+
+{% block form %}
+    /**
+    * Creates a form to edit a {{ entity }} entity.
+    *
+    * @param {{ entity_class }} $entity The entity
+    *
+    * @return \Symfony\Component\Form\Form The form
+    */
+    private function createEditForm({{ entity_class }} $entity)
+    {
+        $form = $this->createForm(new {{ entity_class }}Type(), $entity, array(
+            'action' => $this->generateUrl('{{ route_name_prefix }}_update', array('id' => $entity->getId())),
+            'method' => 'PUT',
+        ));
+
+        $form->add('submit', 'submit', array('label' => 'Update'));
+
+        return $form;
+    }
+{% endblock form %}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/actions/index.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/actions/index.php.twig
@@ -1,0 +1,36 @@
+
+    /**
+{% block phpdoc_method_header %}
+     * Lists all {{ entity }} entities.
+{% endblock phpdoc_method_header %}
+     *
+{% block phpdoc_method_annotations %}
+{% if 'annotation' == format %}
+     * @Route("/", name="{{ route_name_prefix }}")
+     * @Method("GET")
+     * @Template()
+{% endif %}
+{% endblock phpdoc_method_annotations %}
+     */
+{% block method_definition %}
+    public function indexAction()
+{% endblock method_definition %}
+    {
+{% block method_body %}
+        $em = $this->getDoctrine()->getManager();
+
+        $entities = $em->getRepository('{{ bundle }}:{{ entity }}')->findAll();
+{% endblock method_body %}
+
+{% block method_return %}
+{% if 'annotation' == format %}
+        return array(
+            'entities' => $entities,
+        );
+{% else %}
+        return $this->render('{{ bundle }}:{{ entity|replace({'\\': '/'}) }}:index.html.twig', array(
+            'entities' => $entities,
+        ));
+{% endif %}
+{% endblock method_return %}
+    }

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/actions/new.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/actions/new.php.twig
@@ -1,0 +1,37 @@
+
+    /**
+{% block phpdoc_method_header %}
+     * Displays a form to create a new {{ entity }} entity.
+{% endblock phpdoc_method_header %}
+     *
+{% block phpdoc_method_annotations %}
+{% if 'annotation' == format %}
+     * @Route("/new", name="{{ route_name_prefix }}_new")
+     * @Method("GET")
+     * @Template()
+{% endif %}
+{% endblock phpdoc_method_annotations %}
+     */
+{% block method_definition %}
+    public function newAction()
+{% endblock method_definition %}
+    {
+{% block method_body %}
+        $entity = new {{ entity_class }}();
+        $form   = $this->createCreateForm($entity);
+{% endblock method_body %}
+
+{% block method_return %}
+{% if 'annotation' == format %}
+        return array(
+            'entity' => $entity,
+            'form'   => $form->createView(),
+        );
+{% else %}
+        return $this->render('{{ bundle }}:{{ entity|replace({'\\': '/'}) }}:new.html.twig', array(
+            'entity' => $entity,
+            'form'   => $form->createView(),
+        ));
+{% endif %}
+{% endblock method_return %}
+    }

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/actions/show.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/actions/show.php.twig
@@ -1,0 +1,50 @@
+
+    /**
+{% block phpdoc_method_header %}
+     * Finds and displays a {{ entity }} entity.
+{% endblock phpdoc_method_header %}
+     *
+{% block phpdoc_method_annotations %}
+{% if 'annotation' == format %}
+     * @Route("/{id}", name="{{ route_name_prefix }}_show")
+     * @Method("GET")
+     * @Template()
+{% endif %}
+{% endblock phpdoc_method_annotations %}
+     */
+{% block method_definition %}
+    public function showAction($id)
+{% endblock method_definition %}
+    {
+{% block method_body %}
+        $em = $this->getDoctrine()->getManager();
+
+        $entity = $em->getRepository('{{ bundle }}:{{ entity }}')->find($id);
+
+        if (!$entity) {
+            throw $this->createNotFoundException('Unable to find {{ entity }} entity.');
+        }
+{% if 'delete' in actions %}
+
+        $deleteForm = $this->createDeleteForm($id);
+{% endif %}
+{% endblock method_body %}
+
+{% block method_return %}
+{% if 'annotation' == format %}
+        return array(
+            'entity'      => $entity,
+{% if 'delete' in actions %}
+            'delete_form' => $deleteForm->createView(),
+{% endif %}
+        );
+{% else %}
+        return $this->render('{{ bundle }}:{{ entity|replace({'\\': '/'}) }}:show.html.twig', array(
+            'entity'      => $entity,
+{% if 'delete' in actions %}
+            'delete_form' => $deleteForm->createView(),
+{% endif %}
+        ));
+{% endif %}
+{% endblock method_return %}
+    }

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/actions/update.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/actions/update.php.twig
@@ -1,0 +1,53 @@
+    /**
+{% block phpdoc_method_header %}
+     * Edits an existing {{ entity }} entity.
+{% endblock phpdoc_method_header %}
+     *
+{% block phpdoc_method_annotations %}
+{% if 'annotation' == format %}
+     * @Route("/{id}", name="{{ route_name_prefix }}_update")
+     * @Method("PUT")
+     * @Template("{{ bundle }}:{{ entity }}:edit.html.twig")
+{% endif %}
+{% endblock phpdoc_method_annotations %}
+     */
+{% block method_definition %}
+    public function updateAction(Request $request, $id)
+{% endblock method_definition %}
+    {
+{% block method_body %}
+        $em = $this->getDoctrine()->getManager();
+
+        $entity = $em->getRepository('{{ bundle }}:{{ entity }}')->find($id);
+
+        if (!$entity) {
+            throw $this->createNotFoundException('Unable to find {{ entity }} entity.');
+        }
+
+        $deleteForm = $this->createDeleteForm($id);
+        $editForm = $this->createEditForm($entity);
+        $editForm->handleRequest($request);
+
+        if ($editForm->isValid()) {
+            $em->flush();
+
+            return $this->redirect($this->generateUrl('{{ route_name_prefix }}_edit', array('id' => $id)));
+        }
+{% endblock method_body %}
+
+{% block method_return %}
+{% if 'annotation' == format %}
+        return array(
+            'entity'      => $entity,
+            'edit_form'   => $editForm->createView(),
+            'delete_form' => $deleteForm->createView(),
+        );
+{% else %}
+        return $this->render('{{ bundle }}:{{ entity|replace({'\\': '/'}) }}:edit.html.twig', array(
+            'entity'      => $entity,
+            'edit_form'   => $editForm->createView(),
+            'delete_form' => $deleteForm->createView(),
+        ));
+{% endif %}
+{% endblock method_return %}
+    }

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/config/routing.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/config/routing.php.twig
@@ -1,0 +1,60 @@
+<?php
+
+{% block use_statements %}
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\Route;
+{% endblock use_statements %}
+
+{% block definition %}
+$collection = new RouteCollection();
+{% endblock definition %}
+
+{% block body %}
+{% if 'index' in actions %}
+$collection->add('{{ route_name_prefix }}', new Route('/', array(
+    '_controller' => '{{ bundle }}:{{ entity }}:index',
+)));
+{% endif %}
+
+{% if 'show' in actions %}
+$collection->add('{{ route_name_prefix }}_show', new Route('/{id}/show', array(
+    '_controller' => '{{ bundle }}:{{ entity }}:show',
+)));
+{% endif %}
+
+{% if 'new' in actions %}
+$collection->add('{{ route_name_prefix }}_new', new Route('/new', array(
+    '_controller' => '{{ bundle }}:{{ entity }}:new',
+)));
+
+$collection->add('{{ route_name_prefix }}_create', new Route(
+    '/create',
+    array('_controller' => '{{ bundle }}:{{ entity }}:create'),
+    array('_method' => 'post')
+));
+{% endif %}
+
+{% if 'edit' in actions %}
+$collection->add('{{ route_name_prefix }}_edit', new Route('/{id}/edit', array(
+    '_controller' => '{{ bundle }}:{{ entity }}:edit',
+)));
+
+$collection->add('{{ route_name_prefix }}_update', new Route(
+    '/{id}/update',
+    array('_controller' => '{{ bundle }}:{{ entity }}:update'),
+    array('_method' => 'post|put')
+));
+{% endif %}
+
+{% if 'delete' in actions %}
+$collection->add('{{ route_name_prefix }}_delete', new Route(
+    '/{id}/delete',
+    array('_controller' => '{{ bundle }}:{{ entity }}:delete'),
+    array('_method' => 'post|delete')
+));
+{% endif %}
+{% endblock body %}
+
+{% block return %}
+return $collection;
+{% endblock return %}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/config/routing.xml.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/config/routing.xml.twig
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+{% block body %}
+    <route id="{{ route_name_prefix }}" path="/">
+        <default key="_controller">{{ bundle }}:{{ entity }}:index</default>
+    </route>
+
+    <route id="{{ route_name_prefix }}_show" path="/{id}/show">
+        <default key="_controller">{{ bundle }}:{{ entity }}:show</default>
+    </route>
+
+{% if 'new' in actions %}
+    <route id="{{ route_name_prefix }}_new" path="/new">
+        <default key="_controller">{{ bundle }}:{{ entity }}:new</default>
+    </route>
+
+    <route id="{{ route_name_prefix }}_create" path="/create">
+        <default key="_controller">{{ bundle }}:{{ entity }}:create</default>
+        <requirement key="_method">post</requirement>
+    </route>
+{% endif %}
+
+{% if 'edit' in actions %}
+    <route id="{{ route_name_prefix }}_edit" path="/{id}/edit">
+        <default key="_controller">{{ bundle }}:{{ entity }}:edit</default>
+    </route>
+
+    <route id="{{ route_name_prefix }}_update" path="/{id}/update">
+        <default key="_controller">{{ bundle }}:{{ entity }}:update</default>
+        <requirement key="_method">post|put</requirement>
+    </route>
+{% endif %}
+
+{% if 'delete' in actions %}
+    <route id="{{ route_name_prefix }}_delete" path="/{id}/delete">
+        <default key="_controller">{{ bundle }}:{{ entity }}:delete</default>
+        <requirement key="_method">post|delete</requirement>
+    </route>
+{% endif %}
+{% endblock body %}
+
+</routes>

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/config/routing.yml.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/config/routing.yml.twig
@@ -1,0 +1,40 @@
+{% if 'index' in actions %}
+{{ route_name_prefix }}:
+    path:     /
+    defaults: { _controller: "{{ bundle }}:{{ entity }}:index" }
+{% endif %}
+
+{% if 'show' in actions %}
+{{ route_name_prefix }}_show:
+    path:     /{id}/show
+    defaults: { _controller: "{{ bundle }}:{{ entity }}:show" }
+{% endif %}
+
+{% if 'new' in actions %}
+{{ route_name_prefix }}_new:
+    path:     /new
+    defaults: { _controller: "{{ bundle }}:{{ entity }}:new" }
+
+{{ route_name_prefix }}_create:
+    path:     /create
+    defaults: { _controller: "{{ bundle }}:{{ entity }}:create" }
+    requirements: { _method: post }
+{% endif %}
+
+{% if 'edit' in actions %}
+{{ route_name_prefix }}_edit:
+    path:     /{id}/edit
+    defaults: { _controller: "{{ bundle }}:{{ entity }}:edit" }
+
+{{ route_name_prefix }}_update:
+    path:     /{id}/update
+    defaults: { _controller: "{{ bundle }}:{{ entity }}:update" }
+    requirements: { _method: post|put }
+{% endif %}
+
+{% if 'delete' in actions %}
+{{ route_name_prefix }}_delete:
+    path:     /{id}/delete
+    defaults: { _controller: "{{ bundle }}:{{ entity }}:delete" }
+    requirements: { _method: post|delete }
+{% endif %}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/controller.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/controller.php.twig
@@ -1,0 +1,61 @@
+<?php
+
+namespace {{ namespace }}\Controller{{ entity_namespace ? '\\' ~ entity_namespace : '' }};
+
+{% block use_statements %}
+{% if 'new' in actions or 'edit' in actions or 'delete' in actions %}
+use Symfony\Component\HttpFoundation\Request;
+{%- endif %}
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+{% if 'annotation' == format -%}
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+{%- endif %}
+
+use {{ namespace }}\Entity\{{ entity }};
+{% if 'new' in actions or 'edit' in actions %}
+use {{ namespace }}\Form\{{ entity }}Type;
+{% endif %}
+{% endblock use_statements %}
+
+/**
+{% block phpdoc_class_header %}
+ * {{ entity }} controller.
+{% endblock phpdoc_class_header %}
+ *
+{% block phpdoc_class_annotations %}
+{% if 'annotation' == format %}
+ * @Route("/{{ route_prefix }}")
+{% endif %}
+{% endblock phpdoc_class_annotations %}
+ */
+{% block class_definition %}
+class {{ entity_class }}Controller extends Controller
+{% endblock class_definition %}
+{
+{% block class_body %}
+    {%- if 'index' in actions %}
+        {%- include 'crud/actions/index.php.twig' %}
+    {%- endif %}
+
+    {%- if 'new' in actions %}
+        {%- include 'crud/actions/create.php.twig' %}
+        {%- include 'crud/actions/new.php.twig' %}
+    {%- endif %}
+
+    {%- if 'show' in actions %}
+        {%- include 'crud/actions/show.php.twig' %}
+    {%- endif %}
+
+    {%- if 'edit' in actions %}
+        {%- include 'crud/actions/edit.php.twig' %}
+        {%- include 'crud/actions/update.php.twig' %}
+    {%- endif %}
+
+    {%- if 'delete' in actions %}
+        {%- include 'crud/actions/delete.php.twig' %}
+    {%- endif %}
+{% endblock class_body %}
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/tests/others/full_scenario.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/tests/others/full_scenario.php.twig
@@ -1,0 +1,44 @@
+
+    public function testCompleteScenario()
+    {
+        // Create a new client to browse the application
+        $client = static::createClient();
+
+        // Create a new entry in the database
+        $crawler = $client->request('GET', '/{{ route_prefix }}/');
+        $this->assertEquals(200, $client->getResponse()->getStatusCode(), "Unexpected HTTP status code for GET /{{ route_prefix }}/");
+        $crawler = $client->click($crawler->selectLink('Create a new entry')->link());
+
+        // Fill in the form and submit it
+        $form = $crawler->selectButton('Create')->form(array(
+            '{{ form_type_name|lower }}[field_name]'  => 'Test',
+            // ... other fields to fill
+        ));
+
+        $client->submit($form);
+        $crawler = $client->followRedirect();
+
+        // Check data in the show view
+        $this->assertGreaterThan(0, $crawler->filter('td:contains("Test")')->count(), 'Missing element td:contains("Test")');
+
+        // Edit the entity
+        $crawler = $client->click($crawler->selectLink('Edit')->link());
+
+        $form = $crawler->selectButton('Update')->form(array(
+            '{{ form_type_name|lower }}[field_name]'  => 'Foo',
+            // ... other fields to fill
+        ));
+
+        $client->submit($form);
+        $crawler = $client->followRedirect();
+
+        // Check the element contains an attribute with value equals "Foo"
+        $this->assertGreaterThan(0, $crawler->filter('[value="Foo"]')->count(), 'Missing element [value="Foo"]');
+
+        // Delete the entity
+        $client->submit($crawler->selectButton('Delete')->form());
+        $crawler = $client->followRedirect();
+
+        // Check the entity has been delete on the list
+        $this->assertNotRegExp('/Foo/', $client->getResponse()->getContent());
+    }

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/tests/others/short_scenario.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/tests/others/short_scenario.php.twig
@@ -1,0 +1,14 @@
+
+    public function testCompleteScenario()
+    {
+        // Create a new client to browse the application
+        $client = static::createClient();
+
+        // Go to the list view
+        $crawler = $client->request('GET', '/{{ route_prefix }}/');
+        $this->assertEquals(200, $client->getResponse()->getStatusCode(), "Unexpected HTTP status code for GET /{{ route_prefix }}/");
+
+        // Go to the show view
+        $crawler = $client->click($crawler->selectLink('show')->link());
+        $this->assertEquals(200, $client->getResponse()->getStatusCode(), "Unexpected HTTP status code");
+    }

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/tests/test.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/tests/test.php.twig
@@ -1,0 +1,24 @@
+<?php
+
+namespace {{ namespace }}\Tests\Controller{{ entity_namespace ? '\\' ~ entity_namespace : '' }};
+
+{% block use_statements %}
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+{% endblock use_statements %}
+
+{% block class_definition %}
+class {{ entity_class }}ControllerTest extends WebTestCase
+{% endblock class_definition %}
+{
+{% block class_body %}
+    /*
+
+{%- if 'new' in actions %}
+    {%- include 'crud/tests/others/full_scenario.php.twig' -%}
+{%- else %}
+    {%- include 'crud/tests/others/short_scenario.php.twig' -%}
+{%- endif %}
+
+    */
+{% endblock class_body %}
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/views/edit.html.twig.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/views/edit.html.twig.twig
@@ -1,0 +1,14 @@
+{% block extends %}
+{{ "{% extends '::base.html.twig' %}" }}
+{% endblock extends %}
+
+{% block body %}
+{{ "{% block body -%}" }}
+    <h1>{{ entity }} edit</h1>
+
+    {{ '{{ form(edit_form) }}' }}
+
+    {% set hide_edit, hide_delete = true, false %}
+    {% include 'crud/views/others/record_actions.html.twig.twig' %}
+{{ "{% endblock %}" }}
+{% endblock body %}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/views/index.html.twig.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/views/index.html.twig.twig
@@ -1,0 +1,64 @@
+{% block extends %}
+{{ "{% extends '::base.html.twig' %}" }}
+{% endblock extends %}
+
+{% block body %}
+{{ "{% block body -%}" }}
+    <h1>{{ entity }} list</h1>
+
+    <table class="records_list">
+        <thead>
+            <tr>
+            {%- for field, metadata in fields %}
+
+                <th>{{ field|capitalize }}</th>
+
+            {%- endfor %}
+
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        {{ '{% for entity in entities %}' }}
+            <tr>
+
+        {%- for field, metadata in fields %}
+            {%- if loop.first and ('show' in actions) %}
+
+                <td><a href="{{ "{{ path('" ~ route_name_prefix ~ "_show', { 'id': entity."~ identifier ~" }) }}" }}">{{ '{{ entity.' ~ field|replace({'_': ''}) ~ ' }}' }}</a></td>
+
+            {%- elseif metadata.type in ['date', 'datetime'] %}
+
+                <td>{{ '{% if entity.' ~ field|replace({'_': ''}) ~ ' %}{{ entity.' ~ field|replace({'_': ''}) ~ '|date(\'Y-m-d H:i:s\') }}{% endif %}' }}</td>
+
+            {%- else %}
+
+                <td>{{ '{{ entity.' ~ field|replace({'_': ''}) ~ ' }}' }}</td>
+
+            {%- endif %}
+
+            {%- if loop.last %}
+
+                <td>
+                    {%- include "crud/views/others/actions.html.twig.twig" %}
+                </td>
+
+            {%- endif %}
+        {%- endfor %}
+
+            </tr>
+        {{ '{% endfor %}' }}
+        </tbody>
+    </table>
+
+    {% if 'new' in actions %}
+    <ul>
+        <li>
+            <a href="{{ "{{ path('" ~ route_name_prefix ~ "_new') }}" }}">
+                Create a new entry
+            </a>
+        </li>
+    </ul>
+    {% endif %}
+{{ "{% endblock %}" }}
+{% endblock body %}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/views/new.html.twig.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/views/new.html.twig.twig
@@ -1,0 +1,14 @@
+{% block extends %}
+{{ "{% extends '::base.html.twig' %}" }}
+{% endblock extends %}
+
+{% block body %}
+{{ "{% block body -%}" }}
+    <h1>{{ entity }} creation</h1>
+
+    {{ '{{ form(form) }}' }}
+
+    {% set hide_edit, hide_delete = true, true %}
+    {% include 'crud/views/others/record_actions.html.twig.twig' %}
+{{ "{% endblock %}" }}
+{% endblock body %}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/views/others/actions.html.twig.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/views/others/actions.html.twig.twig
@@ -1,0 +1,12 @@
+
+                <ul>
+
+                {%- for action in record_actions %}
+
+                    <li>
+                        <a href="{{ "{{ path('" ~ route_name_prefix ~ "_" ~ action ~ "', { 'id': entity."~ identifier ~" }) }}" }}">{{ action }}</a>
+                    </li>
+
+                {%- endfor %}
+
+                </ul>

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/views/others/record_actions.html.twig.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/views/others/record_actions.html.twig.twig
@@ -1,0 +1,17 @@
+<ul class="record_actions">
+    <li>
+        <a href="{{ "{{ path('" ~ route_name_prefix ~ "') }}" }}">
+            Back to the list
+        </a>
+    </li>
+{% if ('edit' in actions) and (not hide_edit) %}
+    <li>
+        <a href="{{ "{{ path('" ~ route_name_prefix ~ "_edit', { 'id': entity."~ identifier ~" }) }}" }}">
+            Edit
+        </a>
+    </li>
+{% endif %}
+{% if ('delete' in actions) and (not hide_delete) %}
+    <li>{{ '{{ form(delete_form) }}' }}</li>
+{% endif %}
+</ul>

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/views/show.html.twig.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/crud/views/show.html.twig.twig
@@ -1,0 +1,36 @@
+{% block extends %}
+{{ "{% extends '::base.html.twig' %}" }}
+{% endblock extends %}
+
+{% block body %}
+{{ "{% block body -%}" }}
+    <h1>{{ entity }}</h1>
+
+    <table class="record_properties">
+        <tbody>
+        {%- for field, metadata in fields %}
+
+            <tr>
+                <th>{{ field|capitalize }}</th>
+
+            {%- if metadata.type in ['date', 'datetime'] %}
+
+                <td>{{ '{{ entity.' ~ field|replace({'_': ''}) ~ '|date(\'Y-m-d H:i:s\') }}' }}</td>
+
+            {%- else %}
+
+                <td>{{ '{{ entity.' ~ field|replace({'_': ''}) ~ ' }}' }}</td>
+
+            {%- endif %}
+
+            </tr>
+
+        {%- endfor %}
+
+        </tbody>
+    </table>
+
+    {% set hide_edit, hide_delete = false, false %}
+    {% include 'crud/views/others/record_actions.html.twig.twig' %}
+{{ "{% endblock %}" }}
+{% endblock body %}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/form/FormType.php.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/skeleton/form/FormType.php.twig
@@ -1,0 +1,51 @@
+<?php
+
+namespace {{ namespace }}\Form{{ entity_namespace ? '\\' ~ entity_namespace : '' }};
+
+{% block use_statements %}
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+{% endblock use_statements %}
+
+{% block class_definition %}
+class {{ form_class }} extends AbstractType
+{% endblock class_definition %}
+{
+{% block class_body %}
+    {%- if fields|length > 0 %}
+    /**
+     * @param FormBuilderInterface $builder
+     * @param array $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+        {%- for field in fields %}
+
+            ->add('{{ field }}')
+        {%- endfor %}
+
+        ;
+    }
+    {% endif %}
+
+    /**
+     * @param OptionsResolverInterface $resolver
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => '{{ namespace }}\Entity{{ entity_namespace ? '\\' ~ entity_namespace : '' }}\{{ entity_class }}'
+        ));
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return '{{ form_type_name }}';
+    }
+{% endblock class_body %}
+}

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/views/Default/index.html.twig
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Resources/views/Default/index.html.twig
@@ -1,0 +1,1 @@
+Hello {{ name }}!

--- a/newscoop/src/Newscoop/PluginGeneratorBundle/Tests/Controller/DefaultControllerTest.php
+++ b/newscoop/src/Newscoop/PluginGeneratorBundle/Tests/Controller/DefaultControllerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Newscoop\PluginGeneratorBundle\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class DefaultControllerTest extends WebTestCase
+{
+    public function testIndex()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/hello/Fabien');
+
+        $this->assertTrue($crawler->filter('html:contains("Hello Fabien")')->count() > 0);
+    }
+}


### PR DESCRIPTION
Symfony generator for Newscoop plugins

CS-5599: Create Newscoop Plugin Generator
initial commit

CS-5599: Create Newscoop Plugin Generator
initial commit for overriden generators

CS-5599: Create Newscoop Plugin Generator
fix AdminController and twig index

CS-5599: Create Newscoop Plugin Generator
fix bug with PluginController and running install/update in the browser

CS-5599: Create Newscoop Plugin Generator
and now I never want to create zip archives in php
...ever again

CS-5599: Create Newscoop Plugin Generator
added vendor option

CS-5599: Create Newscoop Plugin Generator
added preferences to LifecycleSubcriber and fixed bug with dynamic vendor