### PR TITLE
CS-5410: Sets config-dir parameter when URL is not valid and is handled ...

### DIFF
--- a/newscoop/template_engine/classes/CampURIShortNames.php
+++ b/newscoop/template_engine/classes/CampURIShortNames.php
@@ -82,6 +82,8 @@ class CampURIShortNames extends CampURI
                 if ($template->defined()) {
                     $this->m_template = $template;
                 }
+
+                CampTemplate::singleton()->config_dir = APPLICATION_PATH . '/../themes/' . $themePath . '_conf';
             }
 
             CampTemplate::singleton()->trigger_error($e->getMessage());


### PR DESCRIPTION
...via exception

We forgot to port this to 4.3, maybe also master.