### PR TITLE
Behat - added possibility to save response specific field's value to use it later & CS-5633

### DIFF
--- a/features/3_api_topics.feature
+++ b/features/3_api_topics.feature
@@ -7,7 +7,7 @@ Feature: Testing Topics API
         When I request "/topics"
         Then the response is JSON
 
-    Scenario: Creating a new root topic and checking if it has been created successfully
+    Scenario: Creating a new root topic and subtopic, checking if topics have been created successfully
     	Given that I want to make a new topic
 	        And that i have fake "topic" data:
 	                | title            | roottopic      | 4 |
@@ -31,12 +31,12 @@ Feature: Testing Topics API
 	            And the response should contain field "translations"
 				And field "level" in the response should be "0"
 				And field "title" in the response should be "roottopic"
+				And save "id" field under location "topic_id"
 
-    Scenario: Creating a new subtopic and checking if it has been created successfully
     	Given that I want to make a new subtopic
 	        And that i have fake "topic" data:
 	                | title            | <<sentence>>       | 4 |
-	                | parent           | 1                  ||
+	                | parent           | (topic_id)         ||
 
 	        And I'm logged in as "testuser" with "testpassword" with client "1_svdg45ew371vtsdgd29fgvwe5v" and secret "h48fgsmv0due4nexjsy40jdf3sswwr"
         When I submit "topic" data to "/topics"
@@ -56,7 +56,7 @@ Feature: Testing Topics API
 	            And the response should contain field "root"
 	            And the response should contain field "level"
 	            And the response should contain field "translations"
-				And field "parent" in the response should be "1"
+				And field "parent" in the response should be "(topic_id)"
 				And field "level" in the response should be "1"
 
 	Scenario: Getting all the topics

--- a/features/4_api_link_unlink_topic_to_from_article.feature
+++ b/features/4_api_link_unlink_topic_to_from_article.feature
@@ -1,5 +1,5 @@
 Feature: Testing linking/unlinking topics to/from the articles
-    In order to link/ublink topics through the API
+    In order to link/unlink topics through the API
     As a service user
     I want to see if the topics can be linked or unlinked to/from the articles
 

--- a/features/bootstrap/RestContext.php
+++ b/features/bootstrap/RestContext.php
@@ -300,7 +300,7 @@ class RestContext extends BehatContext
      * @Then /^save "([^"]+)" field under location "([^"]*)"$/
      * @param string $fieldName
      * @param string $locationIndex
-     * @return Step|void
+     * @return Step\Then|void
      * @throws Exception
      */
     public function saveFieldValueUnderLocation($fieldName, $locationIndex)

--- a/newscoop/library/Newscoop/Services/SchedulerService.php
+++ b/newscoop/library/Newscoop/Services/SchedulerService.php
@@ -60,7 +60,7 @@ class SchedulerService implements SchedulerServiceInterface
                 $this->em->flush($cronJob);
             }
         } catch (\Exception $e) {
-            throw new \Exception("Could not register job: '$jobName'");
+            throw new \Exception("Could not register job: '$jobName'", 0, $e);
         }
     }
 


### PR DESCRIPTION
***New feature for behat tests***
There is a possibility of saving value of the specific field from the response under some custom defined location.

Saving under specific location, for instance:
```
And save "id" field under location "topic_id"
```

Passing value of the saved location as a parameter to "fake data":
```
| parent           | (topic_id)         ||
```

Checking if the value from the location "(topic_id)" equals the value of the `parent` field from newly created object:
```
And field "parent" in the response should be "(topic_id)"
```

