### PR TITLE
SITE-692: SSO integration support for Newscoop 4.3.x

### DIFF
--- a/newscoop/library/Newscoop/Services/Auth/DoctrineAuthService.php
+++ b/newscoop/library/Newscoop/Services/Auth/DoctrineAuthService.php
@@ -29,10 +29,10 @@ class DoctrineAuthService implements \Zend_Auth_Adapter_Interface
     protected $password;
 
     /** @var bool */
-    protected $is_admin = FALSE;
+    protected $is_admin = false;
 
     /** @var bool */
-    protected $is_external = FALSE;
+    protected $is_external = false;
 
     /**
      * @param Doctrine\ORM\EntityManager $em
@@ -110,7 +110,7 @@ class DoctrineAuthService implements \Zend_Auth_Adapter_Interface
      * @param bool $admin
      * @return Newscoop\Services\AuthService
      */
-    public function setAdmin($admin = TRUE)
+    public function setAdmin($admin = true)
     {
         $this->is_admin = (bool) $admin;
         return $this;
@@ -122,7 +122,7 @@ class DoctrineAuthService implements \Zend_Auth_Adapter_Interface
      * @param bool $external
      * @return Newscoop\Services\AuthService
      */
-    public function setExternal($external = TRUE)
+    public function setExternal($external = true)
     {
         $this->is_external = (bool) $external;
         return $this;

--- a/newscoop/library/Newscoop/Services/Auth/DoctrineAuthService.php
+++ b/newscoop/library/Newscoop/Services/Auth/DoctrineAuthService.php
@@ -31,6 +31,9 @@ class DoctrineAuthService implements \Zend_Auth_Adapter_Interface
     /** @var bool */
     protected $is_admin = FALSE;
 
+    /** @var bool */
+    protected $is_external = FALSE;
+
     /**
      * @param Doctrine\ORM\EntityManager $em
      */
@@ -68,7 +71,7 @@ class DoctrineAuthService implements \Zend_Auth_Adapter_Interface
             return new \Zend_Auth_Result(\Zend_Auth_Result::FAILURE_UNCATEGORIZED, NULL);
         }
 
-        if (!$user->checkPassword($this->password)) {
+        if (!$this->is_external && !$user->checkPassword($this->password)) {
             return new \Zend_Auth_Result(\Zend_Auth_Result::FAILURE_CREDENTIAL_INVALID, NULL);
         }
 
@@ -110,6 +113,18 @@ class DoctrineAuthService implements \Zend_Auth_Adapter_Interface
     public function setAdmin($admin = TRUE)
     {
         $this->is_admin = (bool) $admin;
+        return $this;
+    }
+
+    /**
+     * Set is external constrain
+     *
+     * @param bool $external
+     * @return Newscoop\Services\AuthService
+     */
+    public function setExternal($external = TRUE)
+    {
+        $this->is_external = (bool) $external;
         return $this;
     }
 


### PR DESCRIPTION
this is needed to do zend_auth in the sso plugin