### PR TITLE
Adds link to 'Add publication'-button

### DIFF
--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/views/BackendPublications/index.html.twig
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/views/BackendPublications/index.html.twig
@@ -82,7 +82,7 @@
         <div class="actions">
             <ul class="navigation" style="height: auto;">
                 <li>
-                    <a class="add" href="#">{{ 'publications.buttons.addNew'|trans }}</a>
+                    <a class="add" href="{{ url('newscoop_newscoop_publications_add') }}">{{ 'publications.buttons.addNew'|trans }}</a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
The button which is only shown if there are no publications yet, didn't have a link.