### PR TITLE
bugfixes and improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
 - cd newscoop/
 - composer self-update
 - composer install --prefer-dist
-- "./application/console newscoop:install --fix --database_name newscoop --database_user root"
+- "./application/console newscoop:install --fix --database_name newscoop --database_user root --no-client"
 - sudo php upgrade.php
 - "./application/console oauth:create-client testclient newscoop.dev newscoop.dev --test"
 - "./application/console user:create test@example.org testpassword testuser 'Test Name' 'Test Surname' true 1 1"

--- a/newscoop/extensions/sourcefabric/SourcefabricDevFeed.php
+++ b/newscoop/extensions/sourcefabric/SourcefabricDevFeed.php
@@ -6,7 +6,7 @@ class SourcefabricDevFeed extends FeedWidget
 {
     protected $title = 'Sourcefabric.org blog reader';
 
-    protected $url = 'http://www.sourcefabric.org/en/about/rss_blogs';
+    protected $url = 'http://feeds.feedburner.com/sourcefabric';
 
     /**
      * @setting

--- a/newscoop/extensions/sourcefabric/SourcefabricFeed.php
+++ b/newscoop/extensions/sourcefabric/SourcefabricFeed.php
@@ -6,7 +6,7 @@ class SourcefabricFeed extends FeedWidget
 {
     protected $title = 'Sourcefabric.org News reader';
 
-    protected $url = 'http://www.sourcefabric.org/en/about/rss_news';
+    protected $url = 'http://feeds.feedburner.com/sourcefabric';
 
     /**
      * @setting

--- a/newscoop/install/Resources/sql/upgrade/4.4.x/2015.03.11/topics.php
+++ b/newscoop/install/Resources/sql/upgrade/4.4.x/2015.03.11/topics.php
@@ -119,14 +119,14 @@ try {
                 continue;
             }
 
-            //create root Topic object
-            $topic = new Topic();
-            $topic->setId($topicDetails[0]['id']);
-            $topic->setTitle($topicDetails[0]['name']);
-            $language = $app['orm.em']->getReference("Newscoop\Entity\Language", $topicDetails[0]['languageId']);
-            $locale = $language->getCode();
-
             try {
+                //create root Topic object
+                $topic = new Topic();
+                $topic->setId($topicDetails[0]['id']);
+                $topic->setTitle($topicDetails[0]['name']);
+                $language = $app['orm.em']->getReference("Newscoop\Entity\Language", $topicDetails[0]['languageId']);
+                $locale = $language->getCode();
+
                 $app['topics_service']->saveNewTopic($topic, $locale, true);
                 // loop for each translations and add not added translations
                 // if topic has more translations

--- a/newscoop/library/Newscoop/Tools/Console/Command/InstallNewscoopCommand.php
+++ b/newscoop/library/Newscoop/Tools/Console/Command/InstallNewscoopCommand.php
@@ -5,7 +5,6 @@
  * @copyright 2014 Sourcefabric o.p.s.
  * @license http://www.gnu.org/licenses/gpl-3.0.txt
  */
-
 namespace Newscoop\Tools\Console\Command;
 
 use Symfony\Component\Console;
@@ -76,7 +75,7 @@ class InstallNewscoopCommand extends Console\Command\Command
 
             return;
         } elseif (count($missingReq) > 0 && $fixCommonIssues) {
-            $newscoopDir = realpath(__DIR__ . '/../../../../../');
+            $newscoopDir = realpath(__DIR__.'/../../../../../');
             // set chmods for directories
             exec('chmod -R 777 '.$newscoopDir.'/cache/');
             exec('chmod -R 777 '.$newscoopDir.'/log/');
@@ -129,13 +128,13 @@ class InstallNewscoopCommand extends Console\Command\Command
             $databaseService->loadGeoData($connection);
             $databaseService->saveDatabaseConfiguration($connection);
         } else {
-            throw new \Exception('There is already a database named ' . $connection->getDatabase() . '. If you are sure to overwrite it, use option --database_override. If not, just change the Database Name and continue.', 1);
+            throw new \Exception('There is already a database named '.$connection->getDatabase().'. If you are sure to overwrite it, use option --database_override. If not, just change the Database Name and continue.', 1);
         }
 
         $command = $this->getApplication()->find('cache:clear');
         $arguments = array(
             'command' => 'cache:clear',
-            '--no-warmup' => true
+            '--no-warmup' => true,
         );
 
         $inputCache = new ArrayInput($arguments);
@@ -155,9 +154,11 @@ class InstallNewscoopCommand extends Console\Command\Command
         $finishService->saveInstanceConfig(array(
             'site_title' => $input->getArgument('site_title'),
             'user_email' => $input->getArgument('user_email'),
-            'recheck_user_password' => $input->getArgument('user_password')
+            'recheck_user_password' => $input->getArgument('user_password'),
         ), $connection);
         $output->writeln('<info>Config have been saved successfully.<info>');
+        $finishService->createDefaultOauthClient($input->getArgument('alias'));
+        $output->writeln('<info>Default OAuth client has been created successfully.<info>');
         $output->writeln('<info>Newscoop is installed.<info>');
     }
 }

--- a/newscoop/library/Newscoop/Tools/Console/Command/InstallNewscoopCommand.php
+++ b/newscoop/library/Newscoop/Tools/Console/Command/InstallNewscoopCommand.php
@@ -40,6 +40,7 @@ class InstallNewscoopCommand extends Console\Command\Command
             ->addOption('database_password', null, InputOption::VALUE_REQUIRED, 'Database password')
             ->addOption('database_server_port', null, InputOption::VALUE_OPTIONAL, 'Database server port', '3306')
             ->addOption('database_override', null, InputOption::VALUE_NONE, 'Override existing database')
+            ->addOption('no-client', null, InputOption::VALUE_NONE, 'Don not create OAuth default client')
             ->addArgument('site_title', InputArgument::OPTIONAL, 'Publication name', 'Newscoop publication')
             ->addArgument('user_email', InputArgument::OPTIONAL, 'Admin email', 'admin@newscoop.dev')
             ->addArgument('user_password', InputArgument::OPTIONAL, 'Admin user password', 'password');
@@ -157,8 +158,11 @@ class InstallNewscoopCommand extends Console\Command\Command
             'recheck_user_password' => $input->getArgument('user_password'),
         ), $connection);
         $output->writeln('<info>Config have been saved successfully.<info>');
-        $finishService->createDefaultOauthClient($input->getArgument('alias'));
-        $output->writeln('<info>Default OAuth client has been created successfully.<info>');
+        if (!$input->getOption('no-client')) {
+            $finishService->createDefaultOauthClient($input->getArgument('alias'));
+            $output->writeln('<info>Default OAuth client has been created successfully.<info>');
+        }
+
         $output->writeln('<info>Newscoop is installed.<info>');
     }
 }


### PR DESCRIPTION
- [x] - create oauth client when installing newscoop from console command
- [x] - Added `--no-client` option to Newscoop console command installer so we can disable option to add default oauth client (for example, its needed in travis, where we create test client after newscoop is installed)
- [x] - RSS fields link fix
- [x] - Topics script improvements