### PR TITLE
fix handling xml content  with single items, add comments

### DIFF
--- a/newscoop/application/modules/admin/controllers/ThemesController.php
+++ b/newscoop/application/modules/admin/controllers/ThemesController.php
@@ -317,7 +317,22 @@ class Admin_ThemesController extends Zend_Controller_Action
         $theme = $this->getThemeService()->findById($this->_request->getParam('id'));
         $path = __DIR__.'/../../../../themes/'.$theme->getPath().'theme.xml';
 
-        $this->view->themePlaylists = $playlistsService->loadThemePlaylists($path);
+        $themePlaylists = $playlistsService->loadThemePlaylists($path);
+        if (array_key_exists('template', $themePlaylists['list'])) {
+            $bakThemePlaylists = $themePlaylists;
+            $themePlaylists = array();
+            $themePlaylists['list'][0] = $bakThemePlaylists['list'];
+        }
+
+        foreach($themePlaylists['list'] as $key => $themePlaylist) {
+            if (array_key_exists('@attributes', $themePlaylist['template'])) {
+                $bakThemePlaylist = $themePlaylist;
+                $themePlaylists['list'][0]['template'] = array();
+                $themePlaylists['list'][0]['template'][0] = $bakThemePlaylist['template'];
+            }
+        }
+
+        $this->view->themePlaylists = $themePlaylists;
         $this->view->playlistsAreUpToDate = $playlistsService->checkIfThemePlaylistsAreUpToDate($theme, $this->view->themePlaylists);
         $this->view->theme = $theme;
     }

--- a/newscoop/classes/cache/TemplateCacheHandler_DB.php
+++ b/newscoop/classes/cache/TemplateCacheHandler_DB.php
@@ -99,12 +99,8 @@ class TemplateCacheHandler_DB extends TemplateCacheHandler
         $exp_time += time();
         $tpl_file = md5($tpl_file).substr($tpl_file, -15);
 
-        $uri = CampSite::GetURIInstance();
-        $smarty = CampTemplate::singleton();
-        $campsiteVector = array_merge(
-            $uri->getCampsiteVector(),
-            $smarty->campsiteVector
-        );
+        $smarty = CampTemplate::singleton();        
+        $campsiteVector = $smarty->campsiteVector;
 
         $return = false;
         if ($action != 'clean') {

--- a/newscoop/include/smarty/campsite_plugins/function.render.php
+++ b/newscoop/include/smarty/campsite_plugins/function.render.php
@@ -7,6 +7,28 @@
 /**
  * Campsite render function plugin
  *
+ * Newscoop caching save cached template file content with special vector parameters.
+ * By default vector is filled with 5 parameters:
+ *  * language
+ *  * publication
+ *  * issue
+ *  * section
+ *  * article
+ *
+ * There is also "params" parameter where we can save put array of custom parameters (serialized into string) or string.
+ *
+ * To ignore one or more parameters (to make cached template this same for many articles, sections, issues etc) just set it value to "off"
+ *
+ * You can also provide custom cache lifetime (or set it in admin themes management) - use "cache" parameter. Setting "cache" to off will not cache this rendered file.
+ *
+ * Examples: 
+ *
+ * {{ render file="_tpl/_html-head.tpl" cache="3200" }} - cache "_tpl/_html-head.tpl" file for 3200 seconds with current context vector
+ *
+ * {{ render file="_tpl/_html-head.tpl" publication="2" }} - change default publication value in vector to 2
+ * 
+ * {{ render file="_tpl/_html-head.tpl" article="off" cache="3200" }} - cache "_tpl/_html-head.tpl" file for 3200 seconds for all articles in current vector (section, issue, publication and language)
+ *
  * Type:     function
  * Name:     render
  * Purpose:  template rendering


### PR DESCRIPTION
There was issue that template and playlists service allways exected
array for list and template properties.

I added also example for articlesLists theme.xml declaration and
examples for render function.

i removed also merging campuri vector with smarty vector - i think that it's not needed. Smarty vector in builded from CampUri one on rendering main template action, CampUri vector will not change during request processing.