### PR TITLE
CS-5782 - ignore authentication oauth modal when session is valid

### DIFF
--- a/newscoop/library/Newscoop/Entity/Repository/IssueRepository.php
+++ b/newscoop/library/Newscoop/Entity/Repository/IssueRepository.php
@@ -113,4 +113,16 @@ class IssueRepository extends EntityRepository
 
         return $qb->getQuery();
     }
+
+    public function getLastPublishedByPublication($publicationId)
+    {
+        $query = $this->createQueryBuilder('i')
+            ->select('i.id')
+            ->where('i.publication = :publicationId')
+            ->setParameter('publicationId', $publicationId)
+            ->setMaxResults(1)
+            ->orderBy('i.id', 'DESC');
+
+        return $query->getQuery();
+    }
 }

--- a/newscoop/library/Newscoop/Services/UserService.php
+++ b/newscoop/library/Newscoop/Services/UserService.php
@@ -72,7 +72,7 @@ class UserService
             } elseif ($this->security->getToken()) {
                 if ($this->security->getToken()->getUser()) {
                     $currentUser = $this->security->getToken()->getUser();
-                    if ($this->security->isGranted('IS_AUTHENTICATED_FULLY') || 
+                    if ($this->security->isGranted('IS_AUTHENTICATED_FULLY') ||
                         $this->security->isGranted('IS_AUTHENTICATED_REMEMBERED')
                     ) {
                         $this->currentUser = $currentUser;

--- a/newscoop/src/Newscoop/ArticlesBundle/Resources/public/app/services/comments.js
+++ b/newscoop/src/Newscoop/ArticlesBundle/Resources/public/app/services/comments.js
@@ -5,7 +5,7 @@
 *
 * @class Comments
 */
-angular.module('editorialCommentsApp').factory('Comments', function($http, $activityIndicator) {
+angular.module('editorialCommentsApp').factory('Comments', function($http, $activityIndicator, $window) {
   var Comments = function() {
     this.items = [];
     this.busy = false;
@@ -117,17 +117,19 @@ angular.module('editorialCommentsApp').factory('Comments', function($http, $acti
       order: 'nested'
     });
 
-    if (!$http.defaults.headers.common.Authorization) {
+    if (!$window.sessionStorage.getItem('newscoop.token')) {
       $http.get(Routing.generate("newscoop_gimme_users_getuseraccesstoken", {
         clientId: clientId
       })).success(function(data, status, headers, config) {
         $http.defaults.headers.common.Authorization = 'Bearer ' + data.access_token;
+        $window.sessionStorage.setItem('newscoop.token', data.access_token);
         $http.get(url).success(function (data) {
           this.items = data.items;
           this.busy = false;
         }.bind(this));
-      }.bind(this));
+      });
     } else {
+      $http.defaults.headers.common.Authorization = 'Bearer ' + $window.sessionStorage.getItem('newscoop.token');
       $http.get(url).success(function (data) {
         this.items = data.items;
         this.busy = false;

--- a/newscoop/src/Newscoop/GimmeBundle/Controller/UsersController.php
+++ b/newscoop/src/Newscoop/GimmeBundle/Controller/UsersController.php
@@ -17,7 +17,6 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Newscoop\Exception\AuthenticationException;
 use Symfony\Component\HttpFoundation\Response;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
-use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Newscoop\GimmeBundle\Entity\Client;
 use Newscoop\Entity\User;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -243,16 +242,9 @@ class UsersController extends FOSRestController
      */
     public function logoutAction(Request $request)
     {
-        $token = new AnonymousToken(null, 'anon.');
         $response = new Response();
-        $session = $request->getSession();
-        $request->getSession()->invalidate();
-        $session->set('_security_frontend_area', serialize($token));
-        $session->set('_security_oauth_authorize', serialize($token));
-        $this->get('security.context')->setToken($token);
-        $zendAuth = \Zend_Auth::getInstance();
-        $zendAuth->clearIdentity();
-        setcookie('NO_CACHE', 'NO', time()-3600, '/', '.'.$this->extractDomain($_SERVER['HTTP_HOST']));
+        $logoutHandler = $this->container->get('newscoop_newscoop.security.oauth.logout.success_handler');
+        $logoutHandler->onLogoutSuccess($request);
 
         return $response;
     }

--- a/newscoop/src/Newscoop/GimmeBundle/Controller/UsersController.php
+++ b/newscoop/src/Newscoop/GimmeBundle/Controller/UsersController.php
@@ -14,7 +14,6 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Newscoop\Exception\AuthenticationException;
 use Symfony\Component\HttpFoundation\Response;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
@@ -218,12 +217,6 @@ class UsersController extends FOSRestController
         $loginSuccessHandler = $this->container->get('newscoop_newscoop.security.authentication.frontend.success_handler');
         $loginSuccessHandler->onAuthenticationSuccess($request, $token);
 
-        $zendAuth = \Zend_Auth::getInstance();
-        $authAdapter = $this->get('auth.adapter');
-        $authAdapter->setEmail($user->getEmail())->setPassword($request->request->get('password'));
-        $zendAuth->authenticate($authAdapter);
-        setcookie('NO_CACHE', '1', null, '/', '.'.$this->extractDomain($_SERVER['HTTP_HOST']));
-
         $response->setStatusCode($targetPath ? 302 : 200);
         $response->headers->set(
             'X-Location',
@@ -389,15 +382,7 @@ class UsersController extends FOSRestController
             throw new NotFoundHttpException("Client {$clientId} is not found.");
         }
 
-        $user = $this->container->get('user')->getCurrentUser();
-        if (!$user instanceof User) {
-            /**
-             * TODO Throw AccessDeniedException instead of Exception (related to bug which redirects to Auth controller
-             *  when AccessDeniedException is used.)
-             */
-            throw new \Exception('You do not have the necessary permissions.');
-        }
-
+        $this->container->get('user')->getCurrentUser();
         $redirectUris = $client->getRedirectUris();
         $authUrl = $request->getUriForPath('/oauth/v2/auth');
         $tokenUrl = $request->getUriForPath('/oauth/v2/token');

--- a/newscoop/src/Newscoop/NewscoopBundle/EventListener/IssueListener.php
+++ b/newscoop/src/Newscoop/NewscoopBundle/EventListener/IssueListener.php
@@ -42,7 +42,9 @@ class IssueListener
     public function onRequest(GetResponseEvent $event)
     {
         $onAdminInterface = strpos($event->getRequest()->getRequestUri(), '/admin');
-        if ($onAdminInterface === false && $event->getRequest()->get('_route') != 'newscoop_get_img') {
+        $onApi = strpos($event->getRequest()->get('_route'), 'newscoop_gimme');
+        if ($onAdminInterface === false && $onApi === false &&
+            $event->getRequest()->get('_route') != 'newscoop_get_img') {
             $this->issueService->issueResolver($event->getRequest());
         }
     }

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/config/services.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/config/services.yml
@@ -75,9 +75,7 @@ services:
 
     newscoop_newscoop.security.oauth.success_handler:
         class: %newscoop_newscoop.security.oauth.success_handler.class%
-        public: true
-        calls:
-            - [ setProviderKey, [ 'oauth_authorize' ]]
+        public: false
         arguments:  ['@security.http_utils', {}, '@auth.adapter', '@user']
 
     newscoop_newscoop.security.oauth.logout.success_handler:

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/config/services.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/config/services.yml
@@ -75,7 +75,9 @@ services:
 
     newscoop_newscoop.security.oauth.success_handler:
         class: %newscoop_newscoop.security.oauth.success_handler.class%
-        public: false
+        public: true
+        calls:
+            - [ setProviderKey, [ 'oauth_authorize' ]]
         arguments:  ['@security.http_utils', {}, '@auth.adapter', '@user']
 
     newscoop_newscoop.security.oauth.logout.success_handler:

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/config/services.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/config/services.yml
@@ -80,7 +80,6 @@ services:
 
     newscoop_newscoop.security.oauth.logout.success_handler:
         class: %newscoop_newscoop.security.oauth.logout.success_handler.class%
-        public: false
         arguments:  ['@security.http_utils', '@security.context']
 
     newscoop_newscoop.publication_service:

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/playlists/controllers/playlists.js
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/playlists/controllers/playlists.js
@@ -540,7 +540,7 @@ angular.module('playlistsApp').controller('PlaylistsController', [
 
         $scope.playlist.selected.id = Playlist.getListId();
 
-        if (response[0] !== undefined && response[0].object.articlesModificationTime !== undefined) {
+        if (response && response[0] !== undefined && response[0].object.articlesModificationTime !== undefined) {
             $scope.playlist.selected.articlesModificationTime = response[0].object.articlesModificationTime;
         }
     }

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/playlists/controllers/playlists.js
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/playlists/controllers/playlists.js
@@ -155,7 +155,10 @@ angular.module('playlistsApp').controller('PlaylistsController', [
      */
     $scope.loadAllPlaylists = function () {
         if (_.isEmpty($scope.playlists)) {
-            $scope.playlists = Playlist.getAll();
+            Playlist.getAll().$promise.then(function (response) {
+                console.log(response);
+                $scope.playlists = response.items;
+            });
         }
     }
 

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/playlists/controllers/playlists.js
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/playlists/controllers/playlists.js
@@ -21,8 +21,7 @@ angular.module('playlistsApp').controller('PlaylistsController', [
         $q,
         $timeout,
         $activityIndicator
-        ) {
-
+    ) {
     $scope.isViewing = false;
     $scope.playlist = {};
     $scope.playlists = [];
@@ -155,10 +154,7 @@ angular.module('playlistsApp').controller('PlaylistsController', [
      */
     $scope.loadAllPlaylists = function () {
         if (_.isEmpty($scope.playlists)) {
-            Playlist.getAll().$promise.then(function (response) {
-                console.log(response);
-                $scope.playlists = response.items;
-            });
+            $scope.playlists = Playlist.getAll();
         }
     }
 

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/playlists/services/auth-interceptor.js
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/playlists/services/auth-interceptor.js
@@ -23,7 +23,7 @@ angular.module('playlistsApp').factory('authInterceptor', [
 
                 config.headers = config.headers || {};
                 token = userAuth.token();
-                if (token) {
+                if (token && !config.IS_AUTHORIZATION_HEADER) {
                     config.headers.Authorization = 'Bearer ' + token;
                 }
 
@@ -65,7 +65,6 @@ angular.module('playlistsApp').factory('authInterceptor', [
 
                     userAuth.obtainToken()
                     .then(function (response) {
-                        console.log(response)
                         $http = $injector.get('$http');
 
                         configToRepeat = angular.copy(failedRequestConfig);

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/playlists/services/auth-interceptor.js
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/playlists/services/auth-interceptor.js
@@ -67,7 +67,6 @@ angular.module('playlistsApp').factory('authInterceptor', [
                     .then(function (responseBody) {
                         $http = $injector.get('$http');
 
-                        //retryDeferred.resolve(response);
                         configToRepeat = angular.copy(failedRequestConfig);
                         configToRepeat.IS_RETRY = true;
 
@@ -79,8 +78,6 @@ angular.module('playlistsApp').factory('authInterceptor', [
                         .catch(function () {
                             retryDeferred.reject(responseBody);
                         });
-
-                        retryDeferred.resolve(response);
                     }, function (response) {
                         userAuth.newTokenByLoginModal()
                         .then(function () {
@@ -104,8 +101,6 @@ angular.module('playlistsApp').factory('authInterceptor', [
                             retryDeferred.reject(response);
                         });
                     });
-
-                    //retryDeferred.reject(response);
 
                     return retryDeferred.promise;
                 } else {

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/playlists/services/auth-interceptor.js
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/playlists/services/auth-interceptor.js
@@ -64,9 +64,10 @@ angular.module('playlistsApp').factory('authInterceptor', [
                     retryDeferred = $q.defer();
 
                     userAuth.obtainToken()
-                    .then(function (response) {
+                    .then(function (responseBody) {
                         $http = $injector.get('$http');
 
+                        //retryDeferred.resolve(response);
                         configToRepeat = angular.copy(failedRequestConfig);
                         configToRepeat.IS_RETRY = true;
 
@@ -76,7 +77,7 @@ angular.module('playlistsApp').factory('authInterceptor', [
                             retryDeferred.resolve(newResponse);
                         })
                         .catch(function () {
-                            retryDeferred.reject(response);
+                            retryDeferred.reject(responseBody);
                         });
 
                         retryDeferred.resolve(response);
@@ -99,10 +100,12 @@ angular.module('playlistsApp').factory('authInterceptor', [
                             });
                         })
                         .catch(function () {
-                                // obtaining new token failed, reject the request
+                            // obtaining new token failed, reject the request
                             retryDeferred.reject(response);
                         });
                     });
+
+                    //retryDeferred.reject(response);
 
                     return retryDeferred.promise;
                 } else {

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/playlists/services/playlists.js
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/playlists/services/playlists.js
@@ -37,10 +37,13 @@ angular.module('playlistsApp').factory('Playlist', [
 
             $http.get(url)
             .success(function (response) {
-                response.items.forEach(function (item) {
-                    playlists.push(item);
-                });
-                deferredGet.resolve();
+                if (response.items !== undefined) {
+                    response.items.forEach(function (item) {
+                        playlists.push(item);
+                    });
+
+                    deferredGet.resolve(response);
+                }
             }).error(function (responseBody) {
                 deferredGet.reject(responseBody);
             });

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/playlists/services/user-auth.js
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/playlists/services/user-auth.js
@@ -44,6 +44,10 @@
                 return $window.sessionStorage.getItem('newscoop.token');
             };
 
+            self.setToken = function (token) {
+                return $window.sessionStorage.setItem('newscoop.token', token);
+            };
+
             /**
             * Returns true if the current user is authenticated (=has a token),
             * otherwise false.
@@ -54,6 +58,27 @@
             self.isAuthenticated = function () {
                 return !!$window.sessionStorage.getItem('newscoop.token');
             };
+
+            self.obtainToken = function () {
+                var deferredGet = $q.defer();
+
+                // TODO dont pass Authentication header when geting access_token
+                // so we wont get "invalid_token" when token expired but instead
+                // we can get the new token or modal login form popup when
+                // session will expire, to get new token.
+                $http.get(Routing.generate("newscoop_gimme_users_getuseraccesstoken", {
+                    clientId: clientId
+                }), {IS_RETRY: true})
+                .success(function(response) {
+                    self.setToken(response.access_token);
+                    deferredGet.resolve(response);
+                })
+                .error(function (response) {
+                    deferredGet.reject(response);
+                });
+
+                return deferredGet.promise;
+            }
 
             /**
             * Opens a modal with Newscoop login form. On successful login it

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/playlists/services/user-auth.js
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/playlists/services/user-auth.js
@@ -44,8 +44,13 @@
                 return $window.sessionStorage.getItem('newscoop.token');
             };
 
+            /**
+            * Sets the current oAuth token in sessionStorage.
+            *
+            * @method setToken
+            */
             self.setToken = function (token) {
-                return $window.sessionStorage.setItem('newscoop.token', token);
+                $window.sessionStorage.setItem('newscoop.token', token);
             };
 
             /**
@@ -59,16 +64,20 @@
                 return !!$window.sessionStorage.getItem('newscoop.token');
             };
 
+            /**
+            * Gets access token by client id. Opening a modal when user session
+            * in Newscoop is still valid, is not needed then. Instead a new token
+            * is obtained directly from the API.
+            *
+            * @method obtainToken
+            * @return {Object} promise object
+            */
             self.obtainToken = function () {
                 var deferredGet = $q.defer();
 
-                // TODO dont pass Authentication header when geting access_token
-                // so we wont get "invalid_token" when token expired but instead
-                // we can get the new token or modal login form popup when
-                // session will expire, to get new token.
                 $http.get(Routing.generate("newscoop_gimme_users_getuseraccesstoken", {
                     clientId: clientId
-                }), {IS_RETRY: true})
+                }), {IS_RETRY: true, IS_AUTHORIZATION_HEADER: true})
                 .success(function(response) {
                     self.setToken(response.access_token);
                     deferredGet.resolve(response);

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/public/views/modal-login.html
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/public/views/modal-login.html
@@ -1,5 +1,5 @@
 <div class="modal-login">
     <div class="modal-body">
-        <sf-iframe-login width="100%" height="510"></sf-iframe-login>
+        <sf-iframe-login width="100%" height="440px"></sf-iframe-login>
     </div>
 </div>

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/public/views/modal-login.html
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/public/views/modal-login.html
@@ -1,3 +1,20 @@
+<style>
+.modal-login {
+    background-color: #f2f2f2;
+    -webkit-border-radius: 6px;
+    -moz-border-radius: 6px;
+    -ms-border-radius: 6px;
+    -o-border-radius: 6px;
+    border-radius: 6px;
+}
+.modal-login .modal-body {
+    padding: 0;
+}
+iframe {
+    border: none;
+    outline: none;
+ }
+</style>
 <div class="modal-login">
     <div class="modal-body">
         <sf-iframe-login width="100%" height="440px"></sf-iframe-login>

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/views/PasswordRecovery/index.html.twig
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/views/PasswordRecovery/index.html.twig
@@ -1,7 +1,7 @@
 <html lang="{{ localeFromCookie }}" dir="ltr">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <title>{% block admin_title %}{{ 'Password Recovery'|trans({},'home') }} - {{ parent() }}{% endblock %}</title>
+  <title>{% block admin_title %}{{ 'Password Recovery'|trans({},'home') }}{% endblock %}</title>
   <link rel="shortcut icon" href="{{ Newscoop['ADMIN_IMAGE_BASE_URL'] }}/7773658c3ccbf03954b4dacb029b2229.ico" />
   <link rel="stylesheet" type="text/css" href="{{ Newscoop['ADMIN_STYLE_URL'] }}/admin_stylesheet_new.css" />
   <link rel="stylesheet" type="text/css" href="{{ Newscoop['ADMIN_STYLE_URL'] }}/admin_stylesheet.css" />

--- a/newscoop/src/Newscoop/NewscoopBundle/Security/Http/Authentication/AuthenticationSuccessHandler.php
+++ b/newscoop/src/Newscoop/NewscoopBundle/Security/Http/Authentication/AuthenticationSuccessHandler.php
@@ -60,7 +60,7 @@ class AuthenticationSuccessHandler extends AbstractAuthenticationHandler
 
         $zendAuth = \Zend_Auth::getInstance();
         $this->authAdapter->setUsername($user->getUsername())->setPassword($request->request->get('_password'))->setAdmin(true);
-        $result = $zendAuth->authenticate($this->authAdapter);
+        $zendAuth->authenticate($this->authAdapter);
 
         $OAuthtoken = $this->userService->loginUser($user, 'oauth_authorize');
         $session = $request->getSession();

--- a/newscoop/src/Newscoop/NewscoopBundle/Security/Http/Authentication/AuthenticationSuccessHandler.php
+++ b/newscoop/src/Newscoop/NewscoopBundle/Security/Http/Authentication/AuthenticationSuccessHandler.php
@@ -65,6 +65,9 @@ class AuthenticationSuccessHandler extends AbstractAuthenticationHandler
         $OAuthtoken = $this->userService->loginUser($user, 'oauth_authorize');
         $session = $request->getSession();
         $session->set('_security_oauth_authorize', serialize($OAuthtoken));
+        $frontendToken = $this->userService->loginUser($user, 'frontend_area');
+        $session = $request->getSession();
+        $session->set('_security_frontend_area', serialize($frontendToken));
 
         \Article::UnlockByUser($user->getId());
 

--- a/newscoop/src/Newscoop/NewscoopBundle/Security/Http/Authentication/OAuthSuccessHandler.php
+++ b/newscoop/src/Newscoop/NewscoopBundle/Security/Http/Authentication/OAuthSuccessHandler.php
@@ -35,7 +35,6 @@ class OAuthSuccessHandler extends AbstractAuthenticationHandler
     {
         $this->authAdapter = $authAdapter;
         $this->userService = $userService;
-        $options['target_path_parameter'] = '_failure_path';
 
         parent::__construct($httpUtils, $options);
     }

--- a/newscoop/src/Newscoop/NewscoopBundle/Security/Http/Authentication/OAuthSuccessHandler.php
+++ b/newscoop/src/Newscoop/NewscoopBundle/Security/Http/Authentication/OAuthSuccessHandler.php
@@ -52,10 +52,10 @@ class OAuthSuccessHandler extends AbstractAuthenticationHandler
     public function onAuthenticationSuccess(Request $request, TokenInterface $token)
     {
         $user = $token->getUser();
-        $zendAuth = \Zend_Auth::getInstance();
-        $this->authAdapter->setEmail($user->getEmail())->setPassword($request->request->get('password'));
-        $zendAuth->authenticate($this->authAdapter);
 
+        $zendAuth = \Zend_Auth::getInstance();
+        $this->authAdapter->setUsername($user->getUsername())->setPassword($request->request->get('_password'));
+        $zendAuth->authenticate($this->authAdapter);
         $frontendToken = $this->userService->loginUser($user, 'frontend_area');
         $session = $request->getSession();
         $session->set('_security_frontend_area', serialize($frontendToken));

--- a/newscoop/themes/system_templates/css/main.css
+++ b/newscoop/themes/system_templates/css/main.css
@@ -16,10 +16,9 @@
             max-width: 420px;
             padding: 35px;
             margin: 20px auto;
-            background:#f6f6f6;
+            background:#f2f2f2;
             text-align:center;
             overflow:hidden;
-            border:1px solid #eee;
         }
         .form-signin .form-signin-heading, .form-signin {
             margin-bottom: 10px;
@@ -37,20 +36,16 @@
             z-index: 2;
         }
         .form-signin input[type="text"] {
-            margin-bottom: -1px;
-            border-bottom-left-radius: 0;
-            border-bottom-right-radius: 0;
+            margin-bottom: 20px;
             border-top-style: solid;
             border-right-style: solid;
-            border-bottom-style: none;
+            border-bottom-style: solid;
             border-left-style: solid;
             border-color: #aaa;
         }
         .form-signin input[type="password"] {
             margin-bottom: 10px;
-            border-top-left-radius: 0;
-            border-top-right-radius: 0;
-            border-top-style: none;
+            border-top-style: solid;
             border-right-style: solid;
             border-bottom-style: solid;
             border-left-style: solid;
@@ -59,13 +54,12 @@
         .form-signin-heading {
             color: #444;
             text-align: center;
-            font-size:24px;
-            font-weight:bold;
+            font-size:18px;
+            font-weight: normal;
         }
-        .form-signin img { max-width: 200px; margin-bottom: 20px; margin-left: 10px; }
+        .form-signin img { max-width: 200px; margin-bottom: 20px; margin-left: 10px; margin-top: 20px; }
         .login_error {
             padding: 10px;
         }
         .forgot-password {margin-bottom: 10px; margin-top: 10px; text-align: left;}
         .pull-left, .pull-right {width:49%;}
-    

--- a/newscoop/themes/system_templates/oauth_login.tpl
+++ b/newscoop/themes/system_templates/oauth_login.tpl
@@ -15,9 +15,9 @@
     <link href="/themes/system_templates/css/main.css" rel="stylesheet">
     <style type="text/css" media="screen">
         body {
-            padding-top: 40px;
-            padding-bottom: 40px;
-            background-color: #eee;
+            padding-top: 0px;
+            padding-bottom: 0px;
+            background-color: transparent;
         }
         .fullscreen_bg {
             position: fixed;
@@ -29,7 +29,7 @@
             background-position: 50% 50%;
         }
         .form-signin {
-            max-width: 280px;
+            max-width: 100%;
             padding: 15px;
             margin: 0 auto;
         }
@@ -48,30 +48,8 @@
         .form-signin .form-control:focus {
             z-index: 2;
         }
-        .form-signin input[type="text"] {
-            margin-bottom: -1px;
-            border-bottom-left-radius: 0;
-            border-bottom-right-radius: 0;
-            border-top-style: solid;
-            border-right-style: solid;
-            border-bottom-style: none;
-            border-left-style: solid;
-            border-color: #000;
-        }
-        .form-signin input[type="password"] {
-            margin-bottom: 10px;
-            border-top-left-radius: 0;
-            border-top-right-radius: 0;
-            border-top-style: none;
-            border-right-style: solid;
-            border-bottom-style: solid;
-            border-left-style: solid;
-            border-color: #000;
-        }
         .form-signin-heading {
-            color: #fff;
             text-align: center;
-            text-shadow: 0 2px 2px rgba(0,0,0,0.5);
         }
 
         .login_error {
@@ -96,7 +74,7 @@
 
             <input type="text" class="form-control" placeholder="Login" value="{{ $lastUsername }}" name="_username" required="" autofocus="">
             <input type="password" class="form-control" placeholder="Password" name="_password" required="">
-            <input type="hidden" name="_failure_path" value="{{ $targetPath }}" />
+            <input type="hidden" name="_target_path" value="{{ $targetPath }}" />
             <a class="forgot-password pull-left" href="{{ $view->url(['controller' => 'auth', 'action' => 'password-restore']) }}">Forgot password?</a>
             <button class="btn btn-lg btn-primary btn-block" type="submit">
                 Sign In

--- a/newscoop/themes/system_templates/oauth_result.tpl
+++ b/newscoop/themes/system_templates/oauth_result.tpl
@@ -20,15 +20,18 @@
             max-width: 320px;
             padding: 15px;
             margin: 0 auto;
+            margin-top: 60px;
         }
     </style>
   </head>
 
   <body>
     <div id="container">
+        <center>
         <img src="/themes/system_templates/img/newscoop_logo_big.png" />
-        <h1 class="form-signin-heading text-muted">Authentication finished.</h1>
+        <h1 class="form-signin-heading text-muted"><b>Authentication finished.</b></h1>
         <p>Check result in this page url (with javascript) and continue with returned data</p>
+        </center>
     </div>
     <script type="text/javascript">
         var tokenRegex = new RegExp('access_token=(\\w+)'),


### PR DESCRIPTION
Comparison: (with IssueListener enabled on API and without it, tested on `/api/topics` endpoint)
![zrzut ekranu 2015-05-11 16 27 38](https://cloud.githubusercontent.com/assets/562536/7567076/05954b4a-f7fb-11e4-9f55-da6d6c2c047e.png)



## Obtaining the access token

**When user session in Newscoop is valid**
1. Access token is obtained via `/api/users/access_token` endpoint (no oauth modal).
2. When access token expires, a new token is obtained via `/api/users/access_token` endpoint (no oauth modal).

**When user session in Newscoop is invalid**
1. A modal opens with oauth form, user is redirected to `/oauth/authentication/result` after successful authentication, a new access token is obtained from the redirect uri.

PR also includes:

- [x] - updated oauth login form design
- [x] - password recovery page fix (twig "parent" removal)
- [x] - "authentication finished" page prettify