### PR TITLE
Fix key for article stored in cache

### DIFF
--- a/newscoop/include/smarty/campsite_plugins/function.set_article.php
+++ b/newscoop/include/smarty/campsite_plugins/function.set_article.php
@@ -46,10 +46,6 @@ function smarty_function_set_article($p_params, &$p_smarty)
         return false;
     }
 
-    if ($campsite->article->defined && $campsite->article->number == $attrValue) {
-        return;
-    }
-
     $articleObj = new MetaArticle($campsite->language->number, $articleNumber);
     if ($articleObj->defined) {
         $campsite->article = $articleObj;

--- a/newscoop/library/Newscoop/Services/CacheService.php
+++ b/newscoop/library/Newscoop/Services/CacheService.php
@@ -94,11 +94,17 @@ class CacheService
         }
 
         if (is_array($id)) {
+            foreach ($id as $key => $value) {
+                if (is_object($value)) {
+                    $id[$key] = serialize($value);
+                }
+            }
+
             $id = implode('__', $id);
         }
 
         // make cache key short
-        $id = base64_encode($id.'|'.$this->systemPreferences->SiteSecretKey);
+        $id = md5($id.'|'.$this->systemPreferences->SiteSecretKey);
 
         if ($namespace) {
             $namespace = $this->getNamespace($namespace);

--- a/newscoop/template_engine/classes/CampURIShortNames.php
+++ b/newscoop/template_engine/classes/CampURIShortNames.php
@@ -352,7 +352,7 @@ class CampURIShortNames extends CampURI
         }
 
         $cacheService = \Zend_Registry::get('container')->getService('newscoop.cache');
-        $cacheKey = $cacheService->getCacheKey(array('getArticle', $articleNo, $language), 'article');
+        $cacheKey = $cacheService->getCacheKey(array('getArticle', $articleNo, $language->number), 'article');
         if ($cacheService->contains($cacheKey)) {
              $metaArticle = $cacheService->fetch($cacheKey);
         } else {


### PR DESCRIPTION
* allow resseting article with this same number - it’s required for article change in case of switching context language
* add option to serialize objects passed to cache key
* use md4 for cache keys instead base64_encode