### PR TITLE
TW-75: Adds parameter to sort articles descending

### DIFF
--- a/newscoop/library/Newscoop/Entity/Repository/ArticleRepository.php
+++ b/newscoop/library/Newscoop/Entity/Repository/ArticleRepository.php
@@ -304,7 +304,7 @@ class ArticleRepository extends DatatableSource implements RepositoryInterface
      *
      * @return \Doctrine\ORM\Query
      */
-    public function getArticlesForTopic($publication, $topicId, $language = false, $getResultAndCount = false)
+    public function getArticlesForTopic($publication, $topicId, $language = false, $getResultAndCount = false, $order = null)
     {
         $em = $this->getEntityManager();
 
@@ -314,6 +314,10 @@ class ArticleRepository extends DatatableSource implements RepositoryInterface
             ->where('att.id = :topicId')
             ->join('a.topics', 'att')
             ->setParameter('topicId', $topicId);
+
+        if ($order !== null) {
+            $queryBuilder->orderBy('a.published', $order);
+        }
 
         $countQueryBuilder = $em->getRepository('Newscoop\Entity\Article')
             ->createQueryBuilder('a')


### PR DESCRIPTION
Sometimes it makes more sense to fetch articles from latest to oldest.

I've search in Newscoop for this method and we only use it in place in the API and only specify 2 params there. So this shouldn't break anything.