### PR TITLE
[wip] - CS-5606: Changes temp dir to project cache dir

### DIFF
--- a/newscoop/application/AppKernel.php
+++ b/newscoop/application/AppKernel.php
@@ -21,6 +21,9 @@ class AppKernel extends Kernel
                 date_default_timezone_set($timeZone);
             }
         } catch (\Exception $e) { }
+
+        // Set temp dir for Newscoop to project cache directory
+        putenv(sprintf('TMPDIR=%s/../cache', __DIR__));
     }
 
     public function registerBundles()


### PR DESCRIPTION
Temp files for Jobby will now be put into /cache . Should prevent any issue with the lck files on a multi-newscoop hosting environment.