### PR TITLE
[CS-5814] [Fix] Article Edit sidebar still has the switch 'Visible to non-subscribers'

### DIFF
--- a/newscoop/admin-files/articles/edit_switches_box.php
+++ b/newscoop/admin-files/articles/edit_switches_box.php
@@ -17,8 +17,12 @@ if (empty($userIsBlogger)) { ?>
         class="input_checkbox" <?php if ($articleObj->ratingEnabled()) { ?> checked<?php } ?> <?php if ($inViewMode || !$publishRights) { ?>disabled<?php } ?> />
         <label for="f_rating_enabled"><?php echo $translator->trans('Enable Rating', array(), 'articles'); ?></label>
       </li>
+      <?php
+      $pluginsService = \Zend_Registry::get('container')->get('newscoop.plugins.service');
+      if ($pluginsService->isEnabled('newscoop/newscoop-paywall-bundle')) { ?>
       <li><input type="checkbox" name="f_is_public" id="f_is_public"
         class="input_checkbox" <?php if ($articleObj->isPublic()) { ?> checked<?php } ?> <?php if ($inViewMode || !$publishRights) { ?>disabled<?php } ?> /> <label for="f_is_public"><?php echo $translator->trans('Visible to non-subscribers', array(), 'articles'); ?></label> </li>
+      <?php } ?>
     <?php
     foreach ($dbColumns as $dbColumn) {
         // Custom switches

--- a/newscoop/template_engine/classes/CampContext.php
+++ b/newscoop/template_engine/classes/CampContext.php
@@ -1330,7 +1330,7 @@ final class CampContext
     {
         $pluginsService = \Zend_Registry::get('container')->get('newscoop.plugins.service');
 
-        if ($pluginsService->isInstalled($pluginName) && $pluginsService->isEnabled($pluginName)) {
+        if ($pluginsService->isEnabled($pluginName)) {
             return true;
         }
 


### PR DESCRIPTION
show that switch only when ‚newscoop/newscoop-paywall-bundle’ plugin is
installed