### PR TITLE
Update Js.php

### DIFF
--- a/newscoop/library/Newscoop/Controller/Plugin/Js.php
+++ b/newscoop/library/Newscoop/Controller/Plugin/Js.php
@@ -79,7 +79,7 @@ class Js extends Zend_Controller_Plugin_Abstract
             	"{$currentUrn}{$p_request->getControllerName()}".DIR_SEP."{$p_request->getActionName()}.{$this->_fileSuffix}"
         );
 
-        foreach( $filesToAppend as $path => $urn )
+        foreach( str_replace("//", "/", str_replace('\\', '/', $filesToAppend)) as $path => $urn )
         {
             if( $path == 'script' ) {
                 $this->view->headScript()->appendScript( $urn );


### PR DESCRIPTION
CS-5841: Fix for mixed and doubled slashes. Eg: "\/js/app/admin\_shared.js" is now "/js/app/admin/_shared.js"

This was causing Apache on WAMP stack to throw an issue where it couldn't tell if the file was local or remote and would resolve to // as the file url in turn causing the browser to try and resolve a url without protocol.

Could have done it in regex, decided it wasn't worth it.