### PR TITLE
Update Js.php

### DIFF
--- a/newscoop/library/Newscoop/Controller/Plugin/Js.php
+++ b/newscoop/library/Newscoop/Controller/Plugin/Js.php
@@ -79,7 +79,7 @@ class Js extends Zend_Controller_Plugin_Abstract
             	"{$currentUrn}{$p_request->getControllerName()}".DIR_SEP."{$p_request->getActionName()}.{$this->_fileSuffix}"
         );
 
-        foreach( str_replace("//", DIR_SEP, str_replace('\\', DIR_SEP, $filesToAppend)) as $path => $urn )
+        foreach( str_replace("//", "/", str_replace('\\', "/", $filesToAppend)) as $path => $urn )
         {
             if( $path == 'script' ) {
                 $this->view->headScript()->appendScript( $urn );

--- a/newscoop/library/Newscoop/Controller/Plugin/Js.php
+++ b/newscoop/library/Newscoop/Controller/Plugin/Js.php
@@ -79,7 +79,7 @@ class Js extends Zend_Controller_Plugin_Abstract
             	"{$currentUrn}{$p_request->getControllerName()}".DIR_SEP."{$p_request->getActionName()}.{$this->_fileSuffix}"
         );
 
-        foreach( $filesToAppend as $path => $urn )
+        foreach( str_replace("//", DIR_SEP, str_replace('\\', DIR_SEP, $filesToAppend)) as $path => $urn )
         {
             if( $path == 'script' ) {
                 $this->view->headScript()->appendScript( $urn );


### PR DESCRIPTION
CS-5841: Fixed issue where Apache on Windows was unable to render the correct url for generated JS files in the admin due to mixed forward, back and double slashes.

Output: "\/js/app\_shared.js"

The browser was attempting to resolve the malformed URL to "//js/app/_shared.js" which is an incorrect URI without protocol. Have added check to the for each loop which outputs the final addresses to change all "\" to "/" and then to reduce all "//" to "/" as well.

Tested in Windows Apache and Mac Apache which should also be applicable to Linux Apache.