### PR TITLE
TW-250: Adds allowfullscreen attribute as valid

### DIFF
--- a/newscoop/admin-files/articles/editor_load_tinymce.php
+++ b/newscoop/admin-files/articles/editor_load_tinymce.php
@@ -271,7 +271,7 @@ $().ready(function() {
         file_browser_callback : "campsitemedia",
         relative_urls : false,
         onchange_callback : function() { $('form#article-main').change(); },
-        extended_valid_elements : "iframe[src|width|height|name|align|frameborder|scrolling|marginheight|marginwidth|style|id|class]",
+        extended_valid_elements : "iframe[src|width|height|name|align|frameborder|scrolling|marginheight|marginwidth|style|id|class|allowfullscreen]",
 
         // Theme options
         theme_advanced_buttons1 : "<?php p($theme_buttons1); ?>",


### PR DESCRIPTION
This adds the allowfullscreen attributes to the list of valid attributes
for an iframe-tag in the TinyMCE configuration.