### PR TITLE
CS-5854: Adds css fix so select2 will keep the same width

### DIFF
--- a/newscoop/admin-files/articles/context_box/popup.php
+++ b/newscoop/admin-files/articles/context_box/popup.php
@@ -29,6 +29,7 @@ function toggleDragZonePlaceHolder()
         $('#drag-here-to-add-to-list').css('display', 'block');
     }
 }
+
 function fnLoadContextList(data)
 {
     if (data.code == 200) {

--- a/newscoop/admin-style/admin_stylesheet_context.css
+++ b/newscoop/admin-style/admin_stylesheet_context.css
@@ -62,3 +62,9 @@ fieldset.closed {
     color: #CCCCCC;
     font-size: 20px;	
 }
+
+/* Fix for author and creator filter in content search */
+.smartlist fieldset div.select2 {
+    margin-right: 13px;
+    width: 256px;
+}


### PR DESCRIPTION
When selecting an author or creator, the select2 field would resize to
the length of the name. When removing and then re-adding the filter the
field still had the same width. Which is inconvenient if you've searched
for a short name.