### PR TITLE
don't update change update_time on article update

### DIFF
--- a/newscoop/install/Resources/sql/campsite_core.sql
+++ b/newscoop/install/Resources/sql/campsite_core.sql
@@ -283,7 +283,7 @@ CREATE TABLE `Articles` (
   `ArticleOrder` int(10) unsigned NOT NULL DEFAULT '0',
   `comments_enabled` tinyint(1) NOT NULL DEFAULT '0',
   `comments_locked` tinyint(1) NOT NULL DEFAULT '0',
-  `time_updated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `time_updated` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `object_id` int(11) DEFAULT NULL,
   `webcode` varchar(10) DEFAULT NULL,
   `indexed` timestamp NULL DEFAULT NULL,

--- a/newscoop/install/Resources/sql/upgrade/4.4.x/2015.06.30/tables.sql
+++ b/newscoop/install/Resources/sql/upgrade/4.4.x/2015.06.30/tables.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `Articles` CHANGE `time_updated` `time_updated` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00';


### PR DESCRIPTION
This changes update_time on every article update (like new article
added to section and order of ther articles mush be changed). We manage
update_time manualy in the app.