### PR TITLE
CS-5888: Adds parameter published to list_related_articles

### DIFF
--- a/newscoop/classes/ContextBoxArticle.php
+++ b/newscoop/classes/ContextBoxArticle.php
@@ -91,12 +91,23 @@ class ContextBoxArticle extends DatabaseObject
                 . ' b.id IN (SELECT c.fk_context_id '
                 . '     FROM Articles a, context_articles c '
                 . '     WHERE c.fk_article_no = ' . $params['article']
-                . '     AND a.Number = c.fk_article_no)'
-                . ' ORDER BY a0.PublishDate DESC';
+                . '     AND a.Number = c.fk_article_no)';
+            if (isset($params['published']) && $params['published'] == 'true') {
+                $sql .= ' AND a0.Published = "Y"';
+            }
+            $sql .= ' ORDER BY a0.PublishDate DESC';
         } else {
-            $sql = 'SELECT fk_article_no FROM context_articles'
+            if (isset($params['published']) && $params['published'] == 'true') {
+                $sql = 'SELECT b.fk_article_no FROM context_articles b, Articles a0'
+                . ' WHERE b.fk_context_id = ' . $params['context_box'] .' AND '
+                . ' b.fk_article_no = a0.Number AND '
+                . ' a0.Published = "Y"'
+                . ' ORDER BY b.id';
+            } else {
+                $sql = 'SELECT fk_article_no FROM context_articles'
                 . ' WHERE fk_context_id = ' . $params['context_box']
                 . ' ORDER BY id';
+            }
         }
         if ($p_limit > 0) {
             $sql .= ' LIMIT ' . $p_limit;

--- a/newscoop/include/smarty/campsite_plugins/block.list_related_articles.php
+++ b/newscoop/include/smarty/campsite_plugins/block.list_related_articles.php
@@ -26,6 +26,11 @@ function smarty_block_list_related_articles($p_params, $p_content, &$p_smarty, &
 	$p_smarty->smarty->loadPlugin('smarty_shared_escape_special_chars');
 	$campContext = $p_smarty->getTemplateVars('gimme');
 
+	// Default to true, but not when previewing
+	if (!isset($p_params['published']) && !$campContext->preview) {
+		$p_params['published'] = 'true';
+	}
+
 	if (!isset($p_content)) {
 		$start = $campContext->next_list_start('BoxArticlesList');
 		$boxArticlesList = new BoxArticlesList($start, $p_params);

--- a/newscoop/template_engine/classes/BoxArticlesList.php
+++ b/newscoop/template_engine/classes/BoxArticlesList.php
@@ -56,7 +56,7 @@ class BoxArticlesList extends ListObject
             if ($article->defined() && ($preview || $article->is_published)) {
                 $metaBoxArticlesList[] = $article;
             }
-	}
+    	}
 
         return $metaBoxArticlesList;
     }
@@ -174,6 +174,7 @@ class BoxArticlesList extends ListObject
                     case 'columns':
                     case 'name':
                     case 'order':
+                    case 'published':
                     case 'role':
                         if ($parameter == 'length' || $parameter == 'columns') {
                             $intValue = (int)$value;


### PR DESCRIPTION
On frontend the parameter defaults to true (except when in preview
mode). When the parameter is set to true, it will only select related
articles that are published.