### PR TITLE
BN-220: Always close transaction

### DIFF
--- a/newscoop/library/Newscoop/Entity/Repository/PlaylistArticleRepository.php
+++ b/newscoop/library/Newscoop/Entity/Repository/PlaylistArticleRepository.php
@@ -58,6 +58,8 @@ class PlaylistArticleRepository extends SortableRepository
                 $em->getConnection()->rollback();
                 $em->close();
             }
+        } else {
+            $em->getConnection()->commit();
         }
 
         return $article;


### PR DESCRIPTION
The transaction was not being close when $article was null, causing weird behaviour.