### PR TITLE
CS-5895: Adds check for custom redirect parameter on confirm

### DIFF
--- a/newscoop/application/controllers/RegisterController.php
+++ b/newscoop/application/controllers/RegisterController.php
@@ -126,6 +126,9 @@ class RegisterController extends Zend_Controller_Action
                     $session->set('_security_frontend_area', serialize($token));
                     $OAuthtoken = $this->_helper->service('user')->loginUser($user, 'oauth_authorize');
                     $session->set('_security_oauth_authorize', serialize($OAuthtoken));
+                    if (isset($values['_target_path']) && !empty($values['_target_path'])) {
+                        $this->_helper->redirector->gotoUrl($values['_target_path']);
+                    }
                     $this->_helper->redirector('index', 'dashboard', 'default', array('first' => 1));
                 }
             } catch (InvalidArgumentException $e) {

--- a/newscoop/application/forms/Confirm.php
+++ b/newscoop/application/forms/Confirm.php
@@ -82,6 +82,11 @@ class Application_Form_Confirm extends Zend_Form
             'ignore' => true,
         ));
         $this->getElement('submit')->setOrder(8);
+
+        $this->addElement('hidden', '_target_path', array(
+            'decorators' => array('ViewHelper')
+        ));
+        $this->getElement('_target_path')->setOrder(9);
     }
 
     /**


### PR DESCRIPTION
Replacing {{ $form }} in the file register_confirm.tpl with the following lines will allow you to set a redirect page after a succesful confirm action.

{{ assign var="hiddenelement" value=$form->getElement('_target_path') }}
{{ $hiddenelement->setValue('<my-redirect-url>') }}
{{ $form }}