### PR TITLE
CS-5903: Adds DISTINCT so related article numbers are only returned once

### DIFF
--- a/newscoop/classes/ContextBoxArticle.php
+++ b/newscoop/classes/ContextBoxArticle.php
@@ -85,7 +85,7 @@ class ContextBoxArticle extends DatabaseObject
         }
 
         if (isset($params['role']) && $params['role'] == 'child') {
-            $sql = 'SELECT b.fk_article_no FROM context_boxes b, Articles a0'
+            $sql = 'SELECT DISTINCT b.fk_article_no FROM context_boxes b, Articles a0'
                 . ' WHERE a0.Number = b.fk_article_no AND '
                 . ' a0.Type = "dossier" AND '
                 . ' b.id IN (SELECT c.fk_context_id '
@@ -98,7 +98,7 @@ class ContextBoxArticle extends DatabaseObject
             $sql .= ' ORDER BY a0.PublishDate DESC';
         } else {
             if (isset($params['published']) && $params['published'] == 'true') {
-                $sql = 'SELECT b.fk_article_no FROM context_articles b, Articles a0'
+                $sql = 'SELECT DISTINCT b.fk_article_no FROM context_articles b, Articles a0'
                 . ' WHERE b.fk_context_id = ' . $params['context_box'] .' AND '
                 . ' b.fk_article_no = a0.Number AND '
                 . ' a0.Published = "Y"'


### PR DESCRIPTION
With the addition of the 'published' check, i added a join with the Article table. But i didn't take into account that when an article is translated, it will return the article multiple time (because we dont use the context language here). Since related articles are the same between translations anyway, a simple DISTINCT is enough to prevent duplicate article numbers from being returned.