### PR TITLE
CS-5898: Use issue number fetched from db

### DIFF
--- a/newscoop/admin-files/sections/duplicate.php
+++ b/newscoop/admin-files/sections/duplicate.php
@@ -55,7 +55,7 @@ if ($f_dest_publication_id > 0) {
     $sqlOptions = array("LIMIT" => 50, "ORDER BY" => array("Number" => "DESC"));
 	$allIssues = Issue::GetIssues($f_dest_publication_id, $f_language_id, null, null, null, false, $sqlOptions, true);
 	if (count($allIssues) == 1) {
-		$f_dest_issue_number = $f_src_issue_number;
+		$f_dest_issue_number = $allIssues[0]->getIssueNumber();
 	}
 }
 


### PR DESCRIPTION
Use issue number from issue list, instead of issue from current publication. If the issue list is based on another publication, there is no guarantee that the issue numbers are the same.