### PR TITLE
Adds auto increment to article playlist id

### DIFF
--- a/newscoop/install/Resources/sql/campsite_core.sql
+++ b/newscoop/install/Resources/sql/campsite_core.sql
@@ -2661,7 +2661,7 @@ CREATE TABLE playlist (
 
 DROP TABLE IF EXISTS `playlist_article`;
 CREATE TABLE `playlist_article` (
-  `id_playlist_article` int(11) NOT NULL,
+  `id_playlist_article` int(11) AUTO_INCREMENT NOT NULL,
   `id_playlist` int(11) NOT NULL,
   `article_no` int(11) NOT NULL,
   `article_language` int(11) NOT NULL,

--- a/newscoop/install/Resources/sql/upgrade/4.4.x/2015.08.10/tables.sql
+++ b/newscoop/install/Resources/sql/upgrade/4.4.x/2015.08.10/tables.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `playlist_article` CHANGE `id_playlist_article` `id_playlist_article` INT( 11 ) UNSIGNED NOT NULL AUTO_INCREMENT ;


### PR DESCRIPTION
Re-added the tables.sql to fix it for people who installed Newscoop 4.x