### PR TITLE
IM-2915: Removed date limits from search datepicker

### DIFF
--- a/newscoop/admin-files/lib_campsite.php
+++ b/newscoop/admin-files/lib_campsite.php
@@ -584,8 +584,6 @@ function camp_get_calendar_field($p_fieldName, $p_defaultValue = null,
     <script type="text/javascript"><!--
         $('#<?php echo htmlspecialchars($p_fieldName); ?>').each(function () {
             var settings = {
-                minDate: 1990,
-                maxDate: 2020,
                 dateFormat: 'yy-mm-dd',
                 timeFormat: 'hh:mm:ss',
             };


### PR DESCRIPTION
According to the documentation a number represents the days from today
and not the actual year.