### PR TITLE
add option to fetch hidden article comments

### DIFF
--- a/newscoop/template_engine/classes/ArticleCommentsList.php
+++ b/newscoop/template_engine/classes/ArticleCommentsList.php
@@ -32,7 +32,11 @@ class ArticleCommentsList extends ListObject
 
         $filter = array();
         $filter = $this->m_constraints;
-        $filter['status'] = 'approved';
+        $filter['status'] = array('approved');
+        if ($p_parameters['show_hidden'] === true) {
+            $filter['status'][] = 'hidden';
+        }
+
         $params = array(
             'sFilter' => $filter
         );
@@ -149,6 +153,7 @@ class ArticleCommentsList extends ListObject
 		$parameters = array();
         $parameters['ignore_language'] = false;
         $parameters['ignore_article'] = false;
+        $parameters['show_hidden'] = false;
         foreach ($p_parameters as $parameter=>$value) {
     		$parameter = strtolower($parameter);
     		switch ($parameter) {
@@ -181,6 +186,8 @@ class ArticleCommentsList extends ListObject
                     break;
                 case 'nested':
                     if ($value == 'true') $this->_nested = true;
+                case 'show_hidden':
+                    if ($value == 'true') $parameters[$parameter] = true;
                 default:
     				CampTemplate::singleton()->trigger_error("invalid parameter $parameter in list_article_comments", $p_smarty);
     		}

--- a/newscoop/template_engine/metaclasses/MetaComment.php
+++ b/newscoop/template_engine/metaclasses/MetaComment.php
@@ -51,6 +51,7 @@ final class MetaComment extends MetaDbObject
         $this->m_customProperties['parent'] = 'getParent';
         $this->m_customProperties['has_parent'] = 'hasParent';
         $this->m_customProperties['thread_level'] = 'threadLevel';
+        $this->m_customProperties['status'] = 'getStatus';
 
         $this->m_skipFilter = array('content_real');
     } // fn __construct
@@ -162,5 +163,10 @@ final class MetaComment extends MetaDbObject
     public function threadLevel()
     {
         return $this->m_dbObject->getThreadLevel();
+    }
+
+    protected function getStatus()
+    {
+        return $this->m_dbObject->getStatus();
     }
 }


### PR DESCRIPTION
Template test cases
```smarty
// show only approved comments
{{ list_article_comments }}
  <div class="comment" style="{{ if $gimme->comment->status === "hidden" }}color:#FFF{{ /if }}">
    <p><strong>{{ $gimme->comment->nickname }}</strong><br>
    {{ $gimme->comment->content }}</p>
    <p><em>{{ $gimme->comment->subject }} | <span>{{ $gimme->comment->submit_date|camp_date_format:"%M %e, %Y" }}</span></em></p>
  </div><!-- /.comment -->
{{ /list_article_comments }}
<hr />

// show only approved comments with switch
{{ list_article_comments show_hidden=false }}
  <div class="comment" style="{{ if $gimme->comment->status === "hidden" }}color:#FFF{{ /if }}">
    <p><strong>{{ $gimme->comment->nickname }}</strong><br>
    {{ $gimme->comment->content }}</p>
    <p><em>{{ $gimme->comment->subject }} | <span>{{ $gimme->comment->submit_date|camp_date_format:"%M %e, %Y" }}</span></em></p>
  </div><!-- /.comment -->
{{ /list_article_comments }}
<hr />

// show also hidden comments
{{ list_article_comments show_hidden=true }}
  <div class="comment" style="{{ if $gimme->comment->status === "hidden" }}color:#FFF{{ /if }}">
    <p><strong>{{ $gimme->comment->nickname }}</strong><br>
    {{ $gimme->comment->content }}</p>
    <p><em>{{ $gimme->comment->subject }} | <span>{{ $gimme->comment->submit_date|camp_date_format:"%M %e, %Y" }}</span></em></p>
  </div><!-- /.comment -->
{{ /list_article_comments }}
```