### PR TITLE
CS-5429 - Topic list is opening too long in article editor

### DIFF
--- a/newscoop/install/Resources/sql/upgrade/4.4.x/2015.09.28/data-required.sql
+++ b/newscoop/install/Resources/sql/upgrade/4.4.x/2015.09.28/data-required.sql
@@ -1,0 +1,1 @@
+UPDATE topic_translations as tt INNER JOIN main_topics AS t ON tt.object_id = t.id SET tt.isDefault = 1 WHERE t.title = tt.content;

--- a/newscoop/install/Resources/sql/upgrade/4.4.x/2015.09.28/tables.sql
+++ b/newscoop/install/Resources/sql/upgrade/4.4.x/2015.09.28/tables.sql
@@ -1,0 +1,1 @@
+ALTER TABLE  `topic_translations` ADD  `isDefault` INT( 1 ) NULL DEFAULT NULL;

--- a/newscoop/js/admin.js
+++ b/newscoop/js/admin.js
@@ -292,7 +292,7 @@ function flashMessage(message, type, fixed)
 
     var flash = $('<div class="flash ui-state-' + messageClass + '">' + message + '</div>')
         .appendTo('body')
-        .css('z-index', '10000')
+        .css('z-index', '100000')
         .css('position', 'fixed')
         .css('top', '13px')
         .css('left', '33%')

--- a/newscoop/src/Newscoop/NewscoopBundle/Entity/Topic.php
+++ b/newscoop/src/Newscoop/NewscoopBundle/Entity/Topic.php
@@ -1,11 +1,10 @@
 <?php
+
 /**
- * @package Newscoop\NewscoopBundle
  * @author Rafał Muszyński <rafal.muszynski@sourcefabric.org>
  * @copyright 2014 Sourcefabric z.ú.
  * @license http://www.gnu.org/licenses/gpl-3.0.txt
  */
-
 namespace Newscoop\NewscoopBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
@@ -55,6 +54,13 @@ class Topic
     protected $parent;
 
     /**
+     * @ORM\Column(type="integer", name="parent_id", nullable=true)
+     *
+     * @var int
+     */
+    protected $parentId;
+
+    /**
      * @Gedmo\TreeRoot
      * @ORM\Column(type="integer", nullable=true)
      */
@@ -99,6 +105,7 @@ class Topic
 
     /**
      * @ORM\Column(type="integer", nullable=true)
+     *
      * @var int
      */
     protected $topicOrder;
@@ -118,12 +125,14 @@ class Topic
      *      @ORM\JoinColumn(name="ArticleNr", referencedColumnName="Number"),
      *      @ORM\JoinColumn(name="LanguageId", referencedColumnName="IdLanguage")
      *      })
+     *
      * @var Newscoop\Entity\Article
      */
     protected $articles;
 
     /**
-     * Link to topic articles resource
+     * Link to topic articles resource.
+     *
      * @var string
      */
     protected $articlesLink;
@@ -294,7 +303,7 @@ class Topic
     /**
      * Gets the integer value of parent.
      *
-     * @return integer
+     * @return int
      */
     public function getParentAsInteger()
     {
@@ -318,9 +327,9 @@ class Topic
     }
 
     /**
-     * Checkes if topic is root
+     * Checkes if topic is root.
      *
-     * @return boolean
+     * @return bool
      */
     public function isRoot()
     {
@@ -476,7 +485,7 @@ class Topic
     }
 
     /**
-     * Gets the translations
+     * Gets the translations.
      *
      * @return mixed
      */
@@ -486,7 +495,7 @@ class Topic
     }
 
     /**
-     * Adds the translation
+     * Adds the translation.
      *
      * @param mixed $translations the translations
      *
@@ -501,7 +510,7 @@ class Topic
     }
 
     /**
-     * Checks if there is translation
+     * Checks if there is translation.
      *
      * @param mixed $locale the locale
      *
@@ -513,7 +522,7 @@ class Topic
     }
 
     /**
-     * Gets the translation
+     * Gets the translation.
      *
      * @param mixed $locale the locale
      *
@@ -524,12 +533,12 @@ class Topic
         if ($this->hasTranslation($locale)) {
             return $this->translations[$locale];
         } else {
-            return null;
+            return;
         }
     }
 
     /**
-     * Gets the Used locale to override Translation listener`s locale
+     * Gets the Used locale to override Translation listener`s locale.
      *
      * @return mixed
      */
@@ -539,7 +548,7 @@ class Topic
     }
 
     /**
-     * Sets the Used locale to override Translation listener`s locale
+     * Sets the Used locale to override Translation listener`s locale.
      *
      * @param mixed $locale the locale
      *
@@ -577,7 +586,7 @@ class Topic
     }
 
     /**
-     * Adds Topic to Article
+     * Adds Topic to Article.
      *
      * @param Article $article the Article to attach
      *
@@ -594,7 +603,7 @@ class Topic
     }
 
     /**
-     * Removes Topic from Article
+     * Removes Topic from Article.
      *
      * @param Article $article the Article to deattach topic
      *
@@ -611,7 +620,7 @@ class Topic
     }
 
     /**
-     * Returns topic's title when echo this object
+     * Returns topic's title when echo this object.
      *
      * @return string
      */
@@ -621,7 +630,7 @@ class Topic
     }
 
     /**
-     * Get view
+     * Get view.
      *
      * @return Newscoop\View\TopicView
      */
@@ -637,7 +646,7 @@ class Topic
     }
 
     /**
-     * Gets object
+     * Gets object.
      *
      * @return Topic
      */
@@ -647,7 +656,7 @@ class Topic
     }
 
     /**
-     * Set link to topic articles resource
+     * Set link to topic articles resource.
      *
      * @param string $articlesLink Link to topic articles resource
      */
@@ -659,7 +668,8 @@ class Topic
     }
 
     /**
-     * Get link to topic articles resource
+     * Get link to topic articles resource.
+     *
      * @return string Link to topic articles resource
      */
     public function getArticlesLink()

--- a/newscoop/src/Newscoop/NewscoopBundle/Entity/TopicTranslation.php
+++ b/newscoop/src/Newscoop/NewscoopBundle/Entity/TopicTranslation.php
@@ -1,6 +1,6 @@
 <?php
+
 /**
- * @package Newscoop\NewscoopBundle
  * @author Rafał Muszyński <rafal.muszynski@sourcefabric.org>
  * @copyright 2014 Sourcefabric z.ú.
  * @license http://www.gnu.org/licenses/gpl-3.0.txt
@@ -21,17 +21,18 @@ use Gedmo\Translatable\Entity\MappedSuperclass\AbstractPersonalTranslation;
 class TopicTranslation extends AbstractPersonalTranslation
 {
     /**
-     * Constructor
+     * Constructor.
      *
      * @param string $locale
      * @param string $field
      * @param string $value
      */
-    public function __construct($locale, $field, $value)
+    public function __construct($locale, $field, $value, $isDefault = null)
     {
         $this->setLocale($locale);
         $this->setField($field);
         $this->setContent($value);
+        $this->setIsDefault($isDefault);
     }
 
     /**
@@ -39,4 +40,33 @@ class TopicTranslation extends AbstractPersonalTranslation
      * @ORM\JoinColumn(name="object_id", referencedColumnName="id", onDelete="CASCADE")
      */
     protected $object;
+
+    /**
+     * @ORM\Column(name="isDefault", type="boolean", nullable=true)
+     */
+    protected $isDefault;
+
+    /**
+     * Gets the value of isDefault.
+     *
+     * @return mixed
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets the value of isDefault.
+     *
+     * @param mixed $isDefault the is default
+     *
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+
+        return $this;
+    }
 }

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/public/css/new-design.css
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/public/css/new-design.css
@@ -102,9 +102,12 @@
     line-height: 140%;
 }
 
-.system_pref.topics .angular-ui-tree .angular-ui-tree-node .tree-node .default-wrap span {
-    float: left;
-    padding-right: 10px;
+.system_pref.topics .angular-ui-tree .angular-ui-tree-node .tree-node .default-wrap div {
+    display: inline-flex;
+}
+
+.system_pref.topics .angular-ui-tree .angular-ui-tree-node .tree-node .default-wrap div ul {
+    padding-left: 10px;
 }
 
 .system_pref.topics .angular-ui-tree .angular-ui-tree-node .tree-node .default-wrap .topic-marker {

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/angular-ui-tree-filter.min.js
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/angular-ui-tree-filter.min.js
@@ -43,8 +43,7 @@
                 collection.forEach(function (collectionItem) {
                     foundSoFar = foundSoFar || testForField(collectionItem, pattern, address, scope);
                     if (foundSoFar) {
-                        scope.collapsed = true;
-                        collectionItem.hasAttachedSubtopic = true;
+                        scope.toggler = true;
                     }
                 });
 
@@ -96,17 +95,24 @@
              */
             return function (item, pattern, addresses, scope) {
                 addresses = addresses || uiTreeFilterSettings.addresses;
-                if (pattern !== undefined && pattern.length <= 3) {
-                    scope.collapsed  = false;
+                if (pattern === undefined || pattern === '') {
+                    scope.toggler = false;
+                    if (scope.$parent.$nodeScope) {
+                        scope.$parent.$nodeScope.toggler = false;
+                    }
+                    return true;
+                }
+                if (pattern !== undefined && pattern.length <= 3 && pattern.length > 0) {
+                    scope.toggler = false;
+                    if (scope.$parent.$nodeScope) {
+                        // actually collapse, because by default on load the tree is collapsed
+                        scope.$parent.$nodeScope.expand();
+                    }
 
                     return true;
                 }
 
                 return pattern === undefined || addresses.reduce(function (foundSoFar, fieldName) {
-                    if (!foundSoFar || !testForField(item, pattern, fieldName, scope)) {
-                        scope.collapsed = false;
-                    }
-
                     return foundSoFar || testForField(item, pattern, fieldName, scope);
                 }, false);
             };

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/tree.js
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/public/js/tree.js
@@ -1,768 +1,826 @@
 (function() {
   'use strict';
 
-var app = angular.module('treeApp', ['ui.tree', 'ui.tree-filter', 'ui.highlight', 'checklist-model'])
-  .config(function($interpolateProvider, $httpProvider, uiTreeFilterSettingsProvider) {
+  var app = angular.module('treeApp', ['ui.tree', 'ui.tree-filter', 'ui.highlight', 'checklist-model'])
+    .config(function($interpolateProvider, $httpProvider, uiTreeFilterSettingsProvider) {
       $interpolateProvider.startSymbol('{[{').endSymbol('}]}');
       uiTreeFilterSettingsProvider.descendantCollection = "__children";
       $httpProvider.interceptors.push(function($q, $injector) {
         return {
           'responseError': function(response) {
             var configToRepeat,
-                failedRequestConfig,
-                retryDeferred,
-                $http;
+              failedRequestConfig,
+              retryDeferred,
+              $http;
 
             if (response.config.IS_RETRY) {
-                return $q.reject(response);
+              return $q.reject(response);
             }
 
             if (response.status === 401) {
-                failedRequestConfig = response.config;
-                retryDeferred = $q.defer();
-                $http = $injector.get('$http');
-                configToRepeat = angular.copy(failedRequestConfig);
-                configToRepeat.IS_RETRY = true;
+              failedRequestConfig = response.config;
+              retryDeferred = $q.defer();
+              $http = $injector.get('$http');
+              configToRepeat = angular.copy(failedRequestConfig);
+              configToRepeat.IS_RETRY = true;
 
-                callServer('ping', [], function(json) {
-                    $http(configToRepeat)
-                      .then(function (newResponse) {
-                          delete newResponse.config.IS_RETRY;
-                          retryDeferred.resolve(newResponse);
-                      })
-                      .catch(function () {
-                          retryDeferred.reject(response);
-                      });
-                });
+              callServer('ping', [], function(json) {
+                $http(configToRepeat)
+                  .then(function(newResponse) {
+                    delete newResponse.config.IS_RETRY;
+                    retryDeferred.resolve(newResponse);
+                  })
+                  .catch(function() {
+                    retryDeferred.reject(response);
+                  });
+              });
 
-                return retryDeferred.promise;
+              return retryDeferred.promise;
             } else {
               return $q.reject(response);
             }
           }
         };
       });
+    });
+
+  /**
+   * A factory which keeps routes to manage topics.
+   *
+   * @class Topic
+   */
+  app.factory('TopicsFactory', function($http) {
+    return {
+      getTopics: function(language, articleNumber) {
+        return $http({
+          method: "GET",
+          url: Routing.generate("newscoop_newscoop_topics_tree"),
+          params: {
+            _code: language,
+            _articleNumber: articleNumber
+          }
+        });
+      },
+      getLanguages: function() {
+        return $http.get(Routing.generate("newscoop_newscoop_language_getlanguages"));
+      },
+      isAttached: function(id) {
+        return $http.get(Routing.generate("newscoop_newscoop_topics_isattached", {
+          id: id
+        }));
+      },
+      deleteTopic: function(id) {
+        return $http.post(Routing.generate("newscoop_newscoop_topics_delete", {
+          id: id
+        }));
+      },
+      moveTopic: function(id, params) {
+        return $http({
+          method: "POST",
+          url: Routing.generate("newscoop_newscoop_topics_move", {
+            id: id
+          }),
+          data: params
+        });
+      },
+      deleteTopicTranslation: function(id) {
+        return $http.post(Routing.generate("newscoop_newscoop_topics_deletetranslation", {
+          id: id
+        }));
+      },
+      addTopic: function(formData, language) {
+        return $http({
+          method: "POST",
+          url: Routing.generate("newscoop_newscoop_topics_add"),
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded'
+          },
+          data: $.param(formData),
+          params: {
+            _code: language
+          }
+        });
+      },
+      attachTopics: function(formData, articleNumber, language) {
+        return $http({
+          method: "POST",
+          url: Routing.generate("newscoop_newscoop_topics_attachtopic"),
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded'
+          },
+          data: $.param(formData),
+          params: {
+            _articleNumber: articleNumber,
+            _languageCode: language
+          }
+        });
+      },
+      updateTopic: function(formData, id, language) {
+        return $http({
+          method: "POST",
+          url: Routing.generate("newscoop_newscoop_topics_edit", {
+            id: id
+          }),
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded'
+          },
+          data: $.param(formData),
+          params: {
+            _code: language
+          }
+        });
+      },
+      addTranslation: function(formData, id) {
+        return $http({
+          method: "POST",
+          url: Routing.generate("newscoop_newscoop_topics_addtranslation", {
+            id: id
+          }),
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded'
+          },
+          data: $.param(formData)
+        });
+      },
+    };
   });
 
-/**
-* A factory which keeps routes to manage topics.
-*
-* @class Topic
-*/
-app.factory('TopicsFactory',  function($http) {
-  return {
-        getTopics: function(language, articleNumber) {
-            return $http({
-              method: "GET",
-              url: Routing.generate("newscoop_newscoop_topics_tree"),
-              params: {
-                _code: language,
-                _articleNumber: articleNumber
-              }
-            });
-        },
-        getLanguages: function() {
-            return $http.get(Routing.generate("newscoop_newscoop_language_getlanguages"));
-        },
-        isAttached: function(id) {
-            return $http.get(Routing.generate("newscoop_newscoop_topics_isattached", {id: id}));
-        },
-        deleteTopic: function(id) {
-            return $http.post(Routing.generate("newscoop_newscoop_topics_delete", {id: id}));
-        },
-        moveTopic: function(id, params) {
-            return $http({
-              method: "POST",
-              url: Routing.generate("newscoop_newscoop_topics_move", {id: id}),
-              data: params
-            });
-        },
-        deleteTopicTranslation: function(id) {
-            return $http.post(Routing.generate("newscoop_newscoop_topics_deletetranslation", {id: id}));
-        },
-        addTopic: function(formData, language) {
-          return $http({
-            method: "POST",
-            url: Routing.generate("newscoop_newscoop_topics_add"),
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded'
-            },
-            data: $.param(formData),
-            params: {_code: language}
-          });
-        },
-        attachTopics: function(formData, articleNumber, language) {
-          return $http({
-            method: "POST",
-            url: Routing.generate("newscoop_newscoop_topics_attachtopic"),
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded'
-            },
-            data: $.param(formData),
-            params: {
-              _articleNumber: articleNumber,
-              _languageCode: language
-            }
-          });
-        },
-        updateTopic: function(formData, id, language) {
-          return $http({
-            method: "POST",
-            url: Routing.generate("newscoop_newscoop_topics_edit", {id: id}),
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded'
-            },
-            data: $.param(formData),
-            params: {_code: language}
-          });
-        },
-        addTranslation: function(formData, id) {
-          return $http({
-            method: "POST",
-            url: Routing.generate("newscoop_newscoop_topics_addtranslation", {id: id}),
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded'
-            },
-            data: $.param(formData)
-          });
-        },
-    };
-});
+  /**
+   * AngularJS controller for managing various actions on the topics, e.g.
+   * changing topic's position in tree, adding new topics, adding new translations etc.
+   *
+   * @class treeController
+   */
+  app.controller('treeController', function(TopicsFactory, $filter, $location, $anchorScroll) {
+      var self = this;
 
-/**
-* AngularJS controller for managing various actions on the topics, e.g.
-* changing topic's position in tree, adding new topics, adding new translations etc.
-*
-* @class TreeCtrl
-*/
-app.controller('treeCtrl', function($scope, TopicsFactory, $filter) {
-    $scope.treeOptions = {
-      dropped: function(event) {
-        var closestNode = event.dest.nodesScope.$$childHead;
-        var draggedNode = event.dest.nodesScope.$$childTail;
-        var params = {};
+      self.treeOptions = {
+        dropped: function(event) {
+          var closestNode = event.dest.nodesScope.$$childHead;
+          var draggedNode = event.dest.nodesScope.$$childTail;
+          var params = {};
 
-        if (draggedNode.$first) {
+          if (draggedNode.$first) {
             params['first'] = true;
             if (event.dest.nodesScope.$parent.$modelValue) {
               params['parent'] = event.dest.nodesScope.$parent.$modelValue.id;
             } else {
               params['order'] = [];
               angular.forEach(event.dest.nodesScope.$modelValue, function(value, key) {
-                  params['order'].push(parseInt(value.id));
+                params['order'].push(parseInt(value.id));
               });
 
               params['order'] = params['order'].join();
               if (draggedNode.node.id != draggedNode.node.root) {
-                  params['asRoot'] = true;
+                params['asRoot'] = true;
               }
             }
-        }
+          }
 
-        if (draggedNode.$last) {
+          if (draggedNode.$last) {
             params['last'] = true;
             if (event.dest.nodesScope.$parent.$modelValue) {
               params['parent'] = event.dest.nodesScope.$parent.$modelValue.id;
             } else {
               params['order'] = [];
               angular.forEach(event.dest.nodesScope.$modelValue, function(value, key) {
-                  params['order'].push(parseInt(value.id));
+                params['order'].push(parseInt(value.id));
               });
 
               params['order'] = params['order'].join();
               if (draggedNode.node.id != draggedNode.node.root) {
-                  params['asRoot'] = true;
+                params['asRoot'] = true;
               }
             }
-        }
+          }
 
-        if (draggedNode.$middle) {
+          if (draggedNode.$middle) {
             params['middle'] = true;
             if (event.dest.nodesScope.$parent.$modelValue) {
               var closestIndex = closestNode.$index;
               var draggedIndex = draggedNode.$index;
               if (draggedIndex > closestIndex) {
-                 params['parent'] = closestNode.node.id;
+                params['parent'] = closestNode.node.id;
               }
             } else {
 
               params['order'] = [];
               angular.forEach(event.dest.nodesScope.$modelValue, function(value, key) {
-                  params['order'].push(parseInt(value.id));
+                params['order'].push(parseInt(value.id));
               });
 
               params['order'] = params['order'].join();
               if (draggedNode.node.id != draggedNode.node.root) {
-                  params['asRoot'] = true;
+                params['asRoot'] = true;
               }
             }
 
+          }
+
+          moveTopic(event.source.nodeScope.$modelValue.id, params);
         }
+      };
+      self.treeFilter = $filter('uiTreeFilter');
+      self.availableFields = ['content', 'title'];
+      self.supportedFields = ['content', 'title'];
+      self.deleteDisabled = false;
+      var languageCode = null;
+      var languageSelected = null;
 
-        moveTopic(event.source.nodeScope.$modelValue.id, params);
+      /**
+       * Go to topic function.
+       * This function sets pattern to the current
+       * topic title. Thus, the whole subtree will be found
+       * using the search field, not needed topics won't be shown.
+       * It also scrolls down to the found topic.
+       *
+       * @param {String}  title topic title
+       * @param {Integer} id    topic id
+       */
+      self.goToTopic = function(title, id) {
+        $anchorScroll.yOffset = 300;
+        var newHash = 'node' + id;
+        self.pattern = title;
+        if ($location.hash() !== newHash) {
+          $location.path('scroll')
+          $location.hash(newHash);
+        } else {
+          $anchorScroll();
+        }
       }
-    };
-    $scope.treeFilter = $filter('uiTreeFilter');
-    $scope.availableFields = ['content', 'title'];
-    $scope.supportedFields = ['content', 'title'];
-    $scope.deleteDisabled = false;
-    var languageCode = null;
-    var languageSelected = null;
 
-    /**
-     * Loads all topics. It loads all the topics in tree structure
-     *
-     * @method loadTopicsTree
-     */
-    $scope.loadTopicsTree = function() {
-      TopicsFactory.getTopics().success(function (data) {
-         $scope.data = data.tree;
-      }).error(function(data, status){
+      /**
+       * Loads all topics. It loads all the topics in tree structure
+       *
+       * @method loadTopicsTree
+       * @param {String} current locale
+       */
+      self.loadTopicsTree = function(currentLocale) {
+        TopicsFactory.getTopics().success(function(data) {
+          self.data = data.tree;
+          setLanguageLabels(self.data, currentLocale);
+        }).error(function(data, status) {
           flashMessage(data.message, 'error');
-      });
-    }
+        });
+      }
 
-    TopicsFactory.getLanguages().success(function (data) {
-        $scope.languageList = data.languages;
-    }).error(function(data, status){
+      TopicsFactory.getLanguages().success(function(data) {
+        self.languageList = data.languages;
+      }).error(function(data, status) {
         flashMessage(data.message, 'error');
-    });
+      });
 
-    /**
-     * Moves topic. It moves topic to given position in a tree.
-     *
-     * @method moveTopic
-     * @param draggedNode {string} topic's id which will be moved
-     * @param params {array} parameters e.g. order, parent etc.
-     */
-    var moveTopic = function(draggedNode, params) {
-       TopicsFactory.moveTopic(draggedNode, params).success(function (response) {
+      /**
+       * Moves topic. It moves topic to given position in a tree.
+       *
+       * @method moveTopic
+       * @param draggedNode {string} topic's id which will be moved
+       * @param params {array} parameters e.g. order, parent etc.
+       */
+      var moveTopic = function(draggedNode, params) {
+        TopicsFactory.moveTopic(draggedNode, params).success(function(response) {
           if (response.status) {
             flashMessage(response.message);
           } else {
             flashMessage(response.message, 'error');
           }
-        }).error(function(response, status){
-            flashMessage(response.message, 'error');
+        }).error(function(response, status) {
+          flashMessage(response.message, 'error');
         });
-    }
+      }
 
-    $scope.selectedTopics = {
-      ids: []
-    };
+      self.selectedTopics = {
+        ids: []
+      };
 
-    /**
-     * Get topics assigned to the article
-     *
-     * @param  {Array} array array of all the topics
-     */
-    var getSelectedTopics = function (array) {
+      /**
+       * Get topics assigned to the article
+       *
+       * @param  {Array} array array of all the topics
+       */
+      var getSelectedTopics = function(array) {
         if (array) {
-            for (var i = 0; i < array.length; i++) {
-                if (array[i].attached) {
-                  $scope.selectedTopics.ids.push(array[i].id);
-                }
-
-                getSelectedTopics(array[i].__children);
+          for (var i = 0; i < array.length; i++) {
+            if (array[i].attached) {
+              self.selectedTopics.ids.push(array[i].id);
             }
-        }
-    };
 
-    /**
-     * Removes topic from the array of the topics
-     *
-     * @param  {array} children Array of children
-     * @param  {integer} id     Topic id
-     * @return {boolean}        true or false
-     */
-    var updateList = function (children, id) {
+            getSelectedTopics(array[i].__children);
+          }
+        }
+      };
+
+      /**
+       * Removes topic from the array of the topics
+       *
+       * @param  {array} children Array of children
+       * @param  {integer} id     Topic id
+       * @return {boolean}        true or false
+       */
+      var updateList = function(children, id) {
         if (children) {
-            for (var i = 0; i < children.length; i++) {
-                if (children[i].id == id) {
-                  children.splice(children.indexOf(children[i]), 1);
+          for (var i = 0; i < children.length; i++) {
+            if (children[i].id == id) {
+              children.splice(children.indexOf(children[i]), 1);
 
-                  return true;
-                }
-
-                var found = updateList(children[i].__children, id);
-                if (found) {
-                  return true;
-                }
+              return true;
             }
-        }
-    };
 
-    /**
-     * Removes topic from the array of the topics
-     *
-     * @param  {array} children Array of children
-     * @param  {integer} id     Topic id
-     * @return {boolean}        True when topic removed from array
-     */
-    var updateTranslations = function (children, id) {
+            var found = updateList(children[i].__children, id);
+            if (found) {
+              return true;
+            }
+          }
+        }
+      };
+
+      /**
+       * Removes topic from the array of the topics
+       *
+       * @param  {array} children Array of children
+       * @param  {integer} id     Topic id
+       * @return {boolean}        True when topic removed from array
+       */
+      var updateTranslations = function(children, id) {
         if (children) {
-            for (var i = 0; i < children.length; i++) {
-                angular.forEach(children[i].translations, function(value, key) {
-                  if (value.id == id) {
-                    children[i].translations.splice(children[i].translations.indexOf(value), 1);
+          for (var i = 0; i < children.length; i++) {
+            angular.forEach(children[i].translations, function(value, key) {
+              if (value.id == id) {
+                children[i].translations.splice(children[i].translations.indexOf(value), 1);
+                self.setLanguageLabel(children[i]);
 
-                    return true;
-                  }
-                });
+                return true;
+              }
+            });
 
-                var found = updateTranslations(children[i].__children, id);
-                if (found) {
-                  return true;
-                }
+            var found = updateTranslations(children[i].__children, id);
+            if (found) {
+              return true;
             }
+          }
         }
-    };
+      };
 
-    /**
-     * Removes topic's translation from the array of the topics' translations
-     *
-     * @param  {array} children   Array of children
-     * @param  {integer} id       Topic id
-     * @param  {object}  response Object with data returned from the server
-     * @return {boolean}          True when topic removed from array
-     */
-    var updateAfterAddTranslation = function (children, id, response) {
+      var setLanguageLabels = function (children, currentLocale) {
         if (children) {
-            for (var i = 0; i < children.length; i++) {
-                if (children[i].id == id) {
-                  children[i].translations.push({id: response.topicTranslationId, locale: response.topicTranslationLocale, field: "title", content: response.topicTranslationTitle });
-                  return children[i];
-                }
+          for (var i = 0; i < children.length; i++) {
+            self.setLanguageLabel(children[i], currentLocale);
 
-                var found = updateAfterAddTranslation(children[i].__children, id, response);
-                if (found) {
-                  return found;
-                }
-            }
+            setLanguageLabels(children[i].__children, currentLocale);
+          }
         }
-    };
+      };
 
-    /**
-     * Updates topics' array. It adds a new topic to the array
-     * of the topics when it is added.
-     *
-     * @param  {array} children   Array of children
-     * @param  {integer} id       Topic id
-     * @param  {object}  response Object with data returned from the server
-     * @return {object}           Returns added topic object
-     */
-    var updateAfterAddSubtopic = function (children, id, response) {
+      /**
+       * Removes topic's translation from the array of the topics' translations
+       *
+       * @param  {array} children   Array of children
+       * @param  {integer} id       Topic id
+       * @param  {object}  response Object with data returned from the server
+       * @return {boolean}          True when topic removed from array
+       */
+      var updateAfterAddTranslation = function(children, id, response) {
         if (children) {
-            for (var i = 0; i < children.length; i++) {
-                if (children[i].id == id) {
-                  if (children[i].__children == undefined) {
-                    children[i]['__children'] = [{id: response.topicId, locale: response.locale, title: response.topicTitle }];
-                    children[i]['__children'][0]['translations'] = [{locale: response.locale, field: "title", content: response.topicTitle }];
-                  } else {
-                    children[i].__children.push({
-                      id: response.topicId,
-                      locale: response.locale,
-                      title: response.topicTitle,
-                      translations: [{locale: response.locale, field: "title", content: response.topicTitle }]
-                    });
-                  }
-                  return children[i];
-                }
-
-                var found = updateAfterAddSubtopic(children[i].__children, id, response);
-                if (found) {
-                  return found;
-                }
+          for (var i = 0; i < children.length; i++) {
+            if (children[i].id == id) {
+              children[i].translations.push({
+                id: response.topicTranslationId,
+                locale: response.topicTranslationLocale,
+                field: "title",
+                content: response.topicTranslationTitle
+              });
+              return children[i];
             }
-        }
-    };
 
-    var removeTopicId = null;
-
-    /**
-     * Displays alert to inform user if he/she is sure to remove this topic.
-     * It also checks if topic is assigned to any article and returns number
-     * of articles its assigned to.
-     *
-     * @method removeTopicAlert
-     * @param topicId {integer} topic's id which will be removed
-     */
-    $scope.removeTopicAlert = function(topicId) {
-      removeTopicId = topicId;
-      var attachedInfo = $('#removeAlert').find('.attached-info');
-      attachedInfo.hide();
-      attachedInfo.html('');
-      TopicsFactory.isAttached(removeTopicId).success(function (response) {
-        if (response.status) {
-          attachedInfo.show();
-          attachedInfo.append(response.message);
+            var found = updateAfterAddTranslation(children[i].__children, id, response);
+            if (found) {
+              return found;
+            }
+          }
         }
-      }).error(function(response, status){
+      };
+
+      /**
+       * Updates topics' array. It adds a new topic to the array
+       * of the topics when it is added.
+       *
+       * @param  {array} children   Array of children
+       * @param  {integer} id       Topic id
+       * @param  {object}  response Object with data returned from the server
+       * @return {object}           Returns added topic object
+       */
+      var updateAfterAddSubtopic = function(children, id, response) {
+        if (children) {
+          for (var i = 0; i < children.length; i++) {
+            if (children[i].id == id) {
+              if (children[i].__children == undefined) {
+                children[i]['__children'] = [{
+                  id: response.topicId,
+                  locale: response.locale,
+                  title: response.topicTitle
+                }];
+                children[i]['__children'][0]['translations'] = [{
+                  locale: response.locale,
+                  field: "title",
+                  content: response.topicTitle
+                }];
+
+                self.setLanguageLabel(children[i]['__children'][0], response.locale);
+              } else {
+                var topic = {
+                  id: response.topicId,
+                  locale: response.locale,
+                  title: response.topicTitle,
+                  translations: [{
+                    locale: response.locale,
+                    field: "title",
+                    content: response.topicTitle
+                  }]
+                };
+
+                self.setLanguageLabel(topic, response.locale);
+                children[i].__children.push(topic);
+              }
+
+              return children[i];
+            }
+
+            var found = updateAfterAddSubtopic(children[i].__children, id, response);
+            if (found) {
+              return found;
+            }
+          }
+        }
+      };
+
+      var removeTopicId = null;
+
+      /**
+       * Displays alert to inform user if he/she is sure to remove this topic.
+       * It also checks if topic is assigned to any article and returns number
+       * of articles its assigned to.
+       *
+       * @method removeTopicAlert
+       * @param topicId {integer} topic's id which will be removed
+       */
+      self.removeTopicAlert = function(topicId) {
+        removeTopicId = topicId;
+        var attachedInfo = $('#removeAlert').find('.attached-info');
+        attachedInfo.hide();
+        attachedInfo.html('');
+        TopicsFactory.isAttached(removeTopicId).success(function(response) {
+          if (response.status) {
+            attachedInfo.show();
+            attachedInfo.append(response.message);
+          }
+        }).error(function(response, status) {
           flashMessage(response.message, 'error');
           $('#removeAlert').modal('hide');
-      });
-    }
-
-    /**
-     * Removes topic by given id and closes the alert popup
-     *
-     * @method removeTopic
-     */
-    $scope.removeTopic = function() {
-      $scope.deleteDisabled = true;
-      TopicsFactory.deleteTopic(removeTopicId).success(function (response) {
-        if (response.status) {
-          $('#removeAlert').modal('hide');
-          flashMessage(response.message);
-          updateList($scope.data, removeTopicId);
-        } else {
-          flashMessage(response.message, 'error');
-        }
-        $scope.deleteDisabled = false;
-      }).error(function(response, status){
-        $scope.deleteDisabled = false;
-          flashMessage(response.message, 'error');
-      });
-    };
-
-    /**
-     * Removes topic's translation by given translation id.
-     *
-     * @method removeTranslation
-     */
-    $scope.removeTranslation = function(translationId)
-    {
-      TopicsFactory.deleteTopicTranslation(translationId).success(function (response) {
-        if (response.status) {
-          flashMessage(response.message);
-          updateTranslations($scope.data, translationId);
-        } else {
-          flashMessage(response.message, 'error');
-        }
-      }).error(function(response, status){
-          flashMessage(response.message, 'error');
-      });
-    }
-
-    /**
-     * Toggles the tree.
-     *
-     * @method toggleTopic
-     *
-     * @param scope {object} current scope
-     */
-    $scope.toggleTopic = function(scope) {
-      if (scope.$nodeScope.$modelValue.hasAttachedSubtopic !== undefined) {
-        if (scope.$nodeScope.$modelValue.hasAttachedSubtopic) {
-          scope.$nodeScope.$modelValue.hasAttachedSubtopic = false;
-          scope.$nodeScope.collapse();
-        }
+        });
       }
 
-      scope.toggle();
-    };
+      /**
+       * Removes topic by given id and closes the alert popup
+       *
+       * @method removeTopic
+       */
+      self.removeTopic = function() {
+        self.deleteDisabled = true;
+        TopicsFactory.deleteTopic(removeTopicId).success(function(response) {
+          if (response.status) {
+            $('#removeAlert').modal('hide');
+            flashMessage(response.message);
+            updateList(self.data, removeTopicId);
+          } else {
+            flashMessage(response.message, 'error');
+          }
+          self.deleteDisabled = false;
+        }).error(function(response, status) {
+          self.deleteDisabled = false;
+          flashMessage(response.message, 'error');
+        });
+      };
 
-    /**
-     * Get root nodes.
-     *
-     * @method getRootNodesScope
-     */
-    var getRootNodesScope = function() {
-      return angular.element(document.getElementById("tree-root")).scope();
-    };
-
-    /**
-     * Expand or collapse all elements in the tree
-     *
-     * @method expandCollapseAll
-     */
-    $scope.expandCollapseAll = function() {
-      var scope = getRootNodesScope();
-      if (!scope.ex) {
-        scope.ex = true;
-        scope.showExpanded = true;
-      } else {
-        if (scope.showExpanded) {
-          scope.showExpanded = false;
-        } else {
-          scope.showExpanded = true;
-        }
+      /**
+       * Removes topic's translation by given translation id.
+       *
+       * @method removeTranslation
+       */
+      self.removeTranslation = function(translationId) {
+        TopicsFactory.deleteTopicTranslation(translationId).success(function(response) {
+          if (response.status) {
+            flashMessage(response.message);
+            updateTranslations(self.data, translationId);
+          } else {
+            flashMessage(response.message, 'error');
+          }
+        }).error(function(response, status) {
+          flashMessage(response.message, 'error');
+        });
       }
-    };
 
-    /**
-     * Hides/shows more options of the tree node
-     *
-     * @method startEditing
-     * @parent scope {object} currently selected element in a tree
-     */
-    $scope.startEditing = function(scope) {
-      if (scope.editing) {
+      /**
+       * Expand or collapse all elements in the tree
+       *
+       * @method expandCollapseAll
+       */
+      self.expandCollapseAll = function() {
+          if (self.showExpanded) {
+            self.showExpanded = false;
+          } else {
+            self.showExpanded = true;
+          }
+      };
+
+      /**
+       * Hides/shows more options of the tree node
+       *
+       * @method startEditing
+       * @parent scope {object} currently selected element in a tree
+       */
+      self.startEditing = function(scope) {
+        if (scope.editing) {
+          scope.editing = false;
+        } else {
+          scope.editing = true;
+          scope.addingSubtopic = false;
+        }
+      };
+
+      /**
+       * Hides/shows options to add new subtopic
+       *
+       * @method showNewSubtopicBox
+       * @parent scope {object} currently selected element in a tree
+       */
+      self.showNewSubtopicBox = function(scope) {
+        if (scope.addingSubtopic) {
+          scope.addingSubtopic = false;
+        } else {
+          scope.addingSubtopic = true;
+          scope.editing = false;
+        }
+      };
+
+      /**
+       * Hide button, hiding extra options like e.g. adding new substopic etc.
+       *
+       * @method hideExtraOptions
+       * @parent scope {object} currently selected element in a tree
+       */
+      self.hideExtraOptions = function(scope) {
         scope.editing = false;
-      } else {
-        scope.editing = true;
         scope.addingSubtopic = false;
       }
-    };
 
-    /**
-     * Hides/shows options to add new subtopic
-     *
-     * @method showNewSubtopicBox
-     * @parent scope {object} currently selected element in a tree
-     */
-    $scope.showNewSubtopicBox = function(scope) {
-      if (scope.addingSubtopic) {
-        scope.addingSubtopic = false;
-      } else {
-        scope.addingSubtopic = true;
-        scope.editing = false;
-      }
-    };
+      self.formData = {};
 
-    /**
-     * Hide button, hiding extra options like e.g. adding new substopic etc.
-     *
-     * @method hideExtraOptions
-     * @parent scope {object} currently selected element in a tree
-     */
-    $scope.hideExtraOptions = function(scope) {
-      scope.editing = false;
-      scope.addingSubtopic = false;
-    }
-
-    $scope.formData = {};
-
-    /**
-     * Adds a new topic
-     *
-     * @method addNewTopic
-     * @param scope {Object} Current topic scope
-     */
-    $scope.addNewTopic = function(scope) {
-      var addFormData = {
-            topic: {},
-            _csrf_token: token
+      /**
+       * Adds a new topic
+       *
+       * @method addNewTopic
+       * @param scope {Object} Current topic scope
+       */
+      self.addNewTopic = function(scope) {
+        var addFormData = {
+          topic: {},
+          _csrf_token: token
         }
 
-      var topic;
-      if (scope !== undefined) {
-        topic = scope.$parent.$nodeScope.$modelValue;
-      }
+        var topic;
+        if (scope !== undefined) {
+          topic = scope.$parent.$nodeScope.$modelValue;
+        }
 
-      if (topic !== undefined) {
+        if (topic !== undefined) {
           addFormData.topic["title"] = topic.newChild[topic.id];
           addFormData.topic["parent"] = topic.id;
           topic.newChild = {};
-      } else {
-        addFormData.topic["title"] = $scope.formData.title;
-      }
+        } else {
+          addFormData.topic["title"] = self.formData.title;
+        }
 
-      TopicsFactory.addTopic(addFormData, languageCode).success(function (response) {
-        if (response.status) {
-          flashMessage(response.message);
-          if (topic == undefined) {
-              $scope.data.unshift({
+        TopicsFactory.addTopic(addFormData, languageCode).success(function(response) {
+          if (response.status) {
+            flashMessage(response.message);
+            if (topic == undefined) {
+              topic = {
                 id: response.topicId,
                 title: response.topicTitle,
                 root: response.topicId,
-                translations: [{ content: response.topicTitle, locale: response.locale}]
-              });
+                translations: [{
+                  content: response.topicTitle,
+                  locale: response.locale
+                }]
+              };
 
+              self.setLanguageLabel(topic, response.locale);
+              self.data.unshift(topic);
+
+            } else {
+              updateAfterAddSubtopic(self.data, topic.id, response);
+              scope.$parent.collapse();
+              self.hideExtraOptions(scope.$parent);
+            }
+            self.formData = null;
           } else {
-            updateAfterAddSubtopic($scope.data, topic.id, response);
-            scope.$parent.$nodeScope.collapsed = true;
+            flashMessage(response.message, 'error');
           }
-          $scope.formData = null;
-        } else {
+        }).error(function(response, status) {
           flashMessage(response.message, 'error');
-        }
-      }).error(function(response, status){
-          flashMessage(response.message, 'error');
-      });
-    };
-
-    /**
-     * Attach topics to the articles. If attaching topics from AES, it also closes the iframe
-     * when the topic has been assigned successfully.
-     *
-     * @method attachTopics
-     * @param articleNumber {integer} article's number to which topic will be assigned
-     * @param languageCode {integer} article's language to which topic will be assigned
-     */
-    $scope.attachTopics = function(articleNumber, languageCode) {
-      var topicsIds = $scope.selectedTopics;
-      TopicsFactory.attachTopics(topicsIds, articleNumber, languageCode).success(function (response) {
-        if (response.status) {
-          flashMessage(response.message);
-          setTimeout(function() {
-            window.parent.$.fancybox.close();
-          }, 1500);
-        } else {
-          flashMessage(response.message, 'error');
-        }
-      }).error(function(response, status){
-          flashMessage(response.message, 'error');
-      });
-    }
-
-    $scope.editFormData = {};
-
-    /**
-     * Updates topic's name
-     *
-     * @method updateTopic
-     * @param node {object} topic object
-     */
-    $scope.updateTopic = function(node) {
-       var postData = {
-          topic: {
-              title: node.title,
-          },
-          _csrf_token: token
-      };
-
-      TopicsFactory.updateTopic(postData, node.id, languageCode).success(function (response) {
-        if (response.status) {
-          flashMessage(response.message);
-          $scope.editFormData = null;
-        } else {
-          flashMessage(response.message, 'error');
-        }
-      }).error(function(response, status){
-          flashMessage(response.message, 'error');
-      });
-    };
-
-    /**
-     * On language change in box when adding a new translation, it assigns selected
-     * language code to the variable so it can be used later elsewhere.
-     *
-     * @method onLanguageChange
-     * @param language {object} language object
-     */
-    $scope.onLanguageChange = function(language) {
-        languageCode = language.code;
-        languageSelected = languageCode;
-    }
-
-    /**
-     * It loads the topics' tree by given language. If selected language is english,
-     * it will load tree with topics by english language.
-     *
-     * @method onFilterLanguageChange
-     * @param langCode {string} language's code
-     * @param articleNumber {integer} article's number
-     */
-    $scope.onFilterLanguageChange = function(langCode, articleNumber) {
-        languageCode = langCode;
-        $scope.languageCode = langCode;
-        TopicsFactory.getTopics(langCode, articleNumber).success(function (data) {
-          $scope.data = data.tree;
-          $scope.pattern = undefined;
-          getSelectedTopics(data.tree);
-        }).error(function(data, status){
-                  console.log(data, status)
-            flashMessage(data.message, 'error');
         });
-    }
-
-    /**
-     * It adds a new translation for given topic object.
-     *
-     * @method addTranslation
-     * @param topicId {integer} topic object
-     */
-    $scope.addTranslation = function(topic) {
-      var postData = {
-          topicTranslation: {
-              title: topic.newTranslation[topic.id],
-              locale: languageSelected
-          },
-          _csrf_token: token
       };
 
-      topic.newTranslation = {};
-      TopicsFactory.addTranslation(postData, topic.id).success(function (response) {
-        if (response.status) {
-          flashMessage(response.message);
-          $scope.languageCode = null;
-          languageCode = null;
-          updateAfterAddTranslation($scope.data, topic.id, response);
-        } else {
+      /**
+       * Attach topics to the articles. If attaching topics from AES, it also closes the iframe
+       * when the topic has been assigned successfully.
+       *
+       * @method attachTopics
+       * @param articleNumber {integer} article's number to which topic will be assigned
+       * @param languageCode {integer} article's language to which topic will be assigned
+       */
+      self.attachTopics = function(articleNumber, languageCode) {
+        var topicsIds = self.selectedTopics;
+        TopicsFactory.attachTopics(topicsIds, articleNumber, languageCode).success(function(response) {
+          if (response.status) {
+            flashMessage(response.message);
+            setTimeout(function() {
+              window.parent.$.fancybox.close();
+            }, 1500);
+          } else {
+            flashMessage(response.message, 'error');
+          }
+        }).error(function(response, status) {
           flashMessage(response.message, 'error');
-        }
-      }).error(function(response, status){
-          flashMessage(response.message, 'error');
-      });
-    };
+        });
+      }
 
-    /**
-     * It sets a proper key: "activeLabel" or "fallback" in translation
-     * object, based on the current locale and selected filter language
-     *
-     * @method setLanguageLabel
-     * @param node {Object} topic
-     * @param langCode {String} Current locale
-     */
-    $scope.setLanguageLabel = function(node, langCode) {
-      angular.forEach(node.translations, function(value, key) {
+      self.editFormData = {};
+
+      /**
+       * Updates topic's name
+       *
+       * @method updateTopic
+       * @param node {object} topic object
+       */
+      self.updateTopic = function(node) {
+        var postData = {
+          topic: {
+            title: node.title,
+          },
+          _csrf_token: token
+        };
+
+        TopicsFactory.updateTopic(postData, node.id, languageCode).success(function(response) {
+          if (response.status) {
+            flashMessage(response.message);
+            self.editFormData = null;
+          } else {
+            flashMessage(response.message, 'error');
+          }
+        }).error(function(response, status) {
+          flashMessage(response.message, 'error');
+        });
+      };
+
+      /**
+       * On language change in box when adding a new translation, it assigns selected
+       * language code to the variable so it can be used later elsewhere.
+       *
+       * @method onLanguageChange
+       * @param language {object} language object
+       */
+      self.onLanguageChange = function(language) {
+        if (language !== undefined) {
+          languageCode = language.code;
+          languageSelected = languageCode;
+        }
+      }
+
+      /**
+       * It loads the topics' tree by given language. If selected language is english,
+       * it will load tree with topics by english language.
+       *
+       * @method onFilterLanguageChange
+       * @param langCode {string} language's code
+       * @param currentLocale {string} current locale
+       * @param articleNumber {integer} article's number
+       */
+      self.onFilterLanguageChange = function(langCode, currentLocale, articleNumber) {
+        if (langCode === undefined) {
+          languageCode = currentLocale;
+        } else {
+          languageCode = langCode;
+        }
+        self.languageCode = languageCode;
+        TopicsFactory.getTopics(langCode, articleNumber).success(function(data) {
+          self.data = data.tree;
+          self.pattern = undefined;
+          getSelectedTopics(data.tree);
+          setLanguageLabels(self.data, currentLocale);
+        }).error(function(data, status) {
+          console.log(data, status)
+          flashMessage(data.message, 'error');
+        });
+      }
+
+      /**
+       * It adds a new translation for given topic object.
+       *
+       * @method addTranslation
+       * @param topicId {integer} topic object
+       */
+      self.addTranslation = function(topic) {
+        var postData = {
+          topicTranslation: {
+            title: topic.newTranslation[topic.id],
+            locale: languageSelected
+          },
+          _csrf_token: token
+        };
+
+        topic.newTranslation = {};
+        TopicsFactory.addTranslation(postData, topic.id).success(function(response) {
+          if (response.status) {
+            flashMessage(response.message);
+            self.languageCode = null;
+            languageCode = null;
+            updateAfterAddTranslation(self.data, topic.id, response);
+            self.setLanguageLabel(topic, languageCode);
+          } else {
+            flashMessage(response.message, 'error');
+          }
+        }).error(function(response, status) {
+          flashMessage(response.message, 'error');
+        });
+      };
+
+      /**
+       * It sets a proper key: "activeLabel" or "fallback" in translation
+       * object, based on the current locale and selected filter language
+       *
+       * @method setLanguageLabel
+       * @param node {Object} topic
+       * @param langCode {String} Current locale
+       */
+      self.setLanguageLabel = function(node, langCode) {
+        angular.forEach(node.translations, function(value, key) {
           if (languageCode === value.locale) {
             value.activeLabel = true;
           }
 
           if (!languageCode) {
             if (value.locale === langCode) {
-               value.activeLabel = true;
+              value.activeLabel = true;
             }
           }
 
-      });
+        });
 
-      // find element with activeLabel set to true
-      // if set to true, set fallback to false
-      // else to true
-      var setfallback = true;
-      var i;
-      angular.forEach(node.translations, function(value, key) {
+        // find element with activeLabel set to true
+        // if set to true, set fallback to false
+        // else to true
+        var setfallback = true;
+        var i;
+        angular.forEach(node.translations, function(value, key) {
           if (value.activeLabel) {
-              setfallback = false;
+            setfallback = false;
           }
-      });
+        });
 
-      for (i = 0; i < node.translations.length; i++) {
-        if (node.translations[i].activeLabel == undefined && setfallback) {
-              node.translations[i].fallback = true;
-        }
-      }
-
-      // if languageCode not in array
-      // choose first locale and set fallback
-      var inArray = false;
-      for (i = 0; i < node.translations.length; i++) {
-        if (angular.equals(node.translations[i].locale, languageCode)) {
-            inArray = true;
-        }
-      }
-
-      if (!inArray) {
-        // restore fallback fields
-        // first translation is always default, so  we unset fallback
-        // for all translations diffrent than default
         for (i = 0; i < node.translations.length; i++) {
-          if (!angular.equals(node.translations[i].locale, languageCode) && i !== 0) {
-              node.translations[i].fallback = false;
+          if (node.translations[i].activeLabel == undefined && setfallback) {
+            node.translations[i].fallback = true;
           }
         }
-      }
-    };
-  })
+
+        // if languageCode not in array
+        // choose first locale and set fallback
+        var inArray = false;
+        for (i = 0; i < node.translations.length; i++) {
+          if (angular.equals(node.translations[i].locale, languageCode)) {
+            inArray = true;
+          }
+        }
+
+        if (!inArray) {
+          // restore fallback fields
+          // first translation is always default, so  we unset fallback
+          // for all translations diffrent than default
+          for (i = 0; i < node.translations.length; i++) {
+            if (!angular.equals(node.translations[i].locale, languageCode) && i !== 0) {
+              node.translations[i].fallback = false;
+            }
+          }
+        }
+      };
+    })
     /**
      * Ad-hoc $sce trusting to be used with ng-bind-html
      */
-        .filter('trust', function ($sce) {
-            return function (val) {
-                return $sce.trustAsHtml(val);
-            };
-        });
+    .filter('trust', function($sce) {
+      return function(val) {
+        return $sce.trustAsHtml(val);
+      };
+    });
 })();

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/topics.en.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/topics.en.yml
@@ -79,4 +79,5 @@ topics:
   tooshort: "Topic name is too short!"
   toolong: "Topic name is too long!"
   attachtopics: "Attach topics"
+  attachedtopics: "Attached topics"
   attached: "This topic is attached to %occurence% article(s). When you remove this topic, it will be automatically detached from all articles it is attached to. If the topic has children topics, they will be also detached."

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/views/Topics/index.html.twig
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/views/Topics/index.html.twig
@@ -23,9 +23,9 @@
 <script type="text/javascript" src="{{ asset('/bundles/newscoopnewscoop/js/angular.min.js') }}"></script>
 <script type="text/javascript" src="{{ asset('/bundles/newscoopnewscoop/js/angular-ui-tree.js') }}"></script>
 <script type="text/javascript" src="{{ asset('/bundles/newscoopnewscoop/js/highlight.min.js') }}"></script>
-<script type="text/javascript" src="{{ asset('/bundles/newscoopnewscoop/js/angular-ui-tree-filter.min.js') }}"></script>
+<script type="text/javascript" src="{{ asset('/bundles/newscoopnewscoop/js/angular-ui-tree-filter.min.js') }}?v=1"></script>
 <script type="text/javascript" src="{{ asset('/bundles/newscoopnewscoop/js/checklist-model.js') }}"></script>
-<script type="text/javascript" src="{{ asset('/bundles/newscoopnewscoop/js/tree.js') }}"></script>
+<script type="text/javascript" src="{{ asset('/bundles/newscoopnewscoop/js/tree.js') }}?v=1"></script>
 <script src="/js/admin.js"></script>
 {% endblock %}
 {% block admin_page_menu_bar %}
@@ -35,10 +35,10 @@
 {% endblock %}
 {% block admin_content %}
 
-<div class="system_pref topics" ng-app="treeApp" ng-controller="treeCtrl" ng-cloak>
+<div class="system_pref topics" ng-app="treeApp" ng-controller="treeController as treeCtrl" ng-cloak>
 {% if compactView %}
 <div class="fixed-top topics-top">
-  <button class="button right-floated with-margin-top" type="button" ng-click="attachTopics('{{ articleNumber }}', '{{ articleLanguage }}')">{{ 'topics.btn.saveandclose'|trans }}</button>
+  <button class="button right-floated with-margin-top" type="button" ng-click="treeCtrl.attachTopics('{{ articleNumber }}', '{{ articleLanguage }}')">{{ 'topics.btn.saveandclose'|trans }}</button>
   <button class="button right-floated with-margin-top" onclick="parent.$.fancybox.close(); return false;">{{ 'topics.btn.close'|trans }}</button>
   <h3>{{ 'topics.title'|trans }} - {{ 'topics.attachtopics'|trans }}</h3>
   </div>
@@ -48,16 +48,32 @@
 
 {% endif %}
 <div class="container">
-<div class="row" ng-init="dim=false; highlight=true; {% if compactView %}onFilterLanguageChange('{{ articleLanguage }}', '{{ articleNumber }}'){% else %}loadTopicsTree(){% endif %}">
+<div class="row" ng-init="dim=false; highlight=true; {% if compactView %}treeCtrl.onFilterLanguageChange('{{ articleLanguage }}', '{{app.request.locale}}', '{{ articleNumber }}'){% else %}treeCtrl.loadTopicsTree('{{app.request.locale}}'){% endif %}">
+{% if compactView %}
+<div class="col-lg-12">
+<h3>{{ 'topics.attachedtopics'|trans }}</h3>
+  <div class="list">
+    {% for topic in assignedTopics %}
+    <div
+       class="tree-node tree-node-content angular-ui-tree-handle angular-ui-tree ng-scope" style="cursor:pointer; background: #E1E9EF; padding: 10px 10px" ng-click="treeCtrl.goToTopic('{{topic.title}}', {{topic.id}})">
+       <div class="default-wrap">
+          <input type="checkbox" ng-click="$event.stopPropagation();" id="selectedCheckbox" checklist-model="treeCtrl.selectedTopics.ids" checklist-value="{{topic.id}}" class="topic-marker"/>
+            {{ topic.path }}
+        </div>
+    </div>
+    {% endfor %}
+  </div>
+</div>
+{% endif %}
         <div class="col-sm-4">
             <h3>{{ 'topics.label.addroot'|trans }}</h3>
             <div class="alert alert-danger" ng-show="addTopicForm.title.$error.maxlength" role="alert">{{ 'topics.toolong'|trans }}</div>
             <div class="alert alert-danger" ng-show="addTopicForm.title.$error.minlength" role="alert">{{ 'topics.tooshort'|trans }}</div>
-            <form class="form-inline" name="addTopicForm" ng-submit="addNewTopic()" role="form">
+            <form class="form-inline" name="addTopicForm" ng-submit="treeCtrl.addNewTopic()" role="form">
                 <div class="row">
                   <div class="col-lg-12">
                     <div class="form-group">
-                      <input type="text" name="title" ng-model="formData.title" required ng-minlength="1" ng-maxlength="60" class="form-control input-sm" id="addNewTopic" placeholder="{{ 'topics.label.topicname'|trans }}">
+                      <input type="text" name="title" ng-model="treeCtrl.formData.title" required ng-minlength="1" ng-maxlength="60" class="form-control input-sm" id="addNewTopic" placeholder="{{ 'topics.label.topicname'|trans }}">
                       <button ng-disabled="addTopicForm.$invalid" type="submit" class="btn btn-sm btn-primary">{{ 'topics.btn.add'|trans }}</button>
                       </div>
                     </div>
@@ -67,14 +83,14 @@
         <div class="col-sm-4">
             <h3>{{ 'topics.label.search'|trans }}</h3>
             <form class="form-inline" name="searchForm" role="form">
-                <input type="search" class="form-control search input-sm" placeholder="{{ 'topics.label.filterplaceholder'|trans }}"  ng-model="pattern">
+                <input type="search" class="form-control search input-sm" placeholder="{{ 'topics.label.filterplaceholder'|trans }}"  ng-model="treeCtrl.pattern">
             </form>
         </div>
         <div class="col-sm-4">
           {% if compactView == false %}
           <h3>{{ 'topics.label.filterbylang'|trans }}</h3>
           <form class="form-inline" name="filterForm" role="form">
-            <select ng-model="langSelected" ng-options='language.code as (language.name + " [" + language.code + "]") for language in languageList' ng-change="onFilterLanguageChange(langSelected)" class="form-control input-sm">
+            <select ng-model="treeCtrl.langSelected" ng-options='language.code as (language.name + " [" + language.code + "]") for language in treeCtrl.languageList' ng-change="treeCtrl.onFilterLanguageChange(treeCtrl.langSelected, '{{app.request.locale}}')" class="form-control input-sm">
             <option value="">{{ 'topics.label.all'|trans }}</option>
             </select>
           </form>
@@ -86,30 +102,30 @@
             <h3>{{ 'topics.label.tree'|trans }}
             <div class="expand-btn pull-right">
                 <span class="label">{{ 'topics.label.expandcollapse'|trans }}</span>
-                <button type="button" class="btn btn-default btn-sm" title="Expand/collapse tree" ng-click="expandCollapseAll(this)"><span class="glyphicon glyphicon-resize-vertical"></span></button>
+                <button type="button" class="btn btn-default btn-sm" title="Expand/collapse tree" ng-click="treeCtrl.expandCollapseAll()"><span class="glyphicon glyphicon-resize-vertical"></span></button>
               </div>
             </h3>
             <!-- Nested node template -->
             <script type="text/ng-template" id="nodes_renderer.html">
               <div ui-tree-handle ng-class="{'active': editing || addingSubtopic}" class="tree-node tree-node-content angular-ui-tree-handle" {% if compactView %}style="cursor:auto" ng-style="{ background: node.attached ? '#E1E9EF' : '#f2f2f2' }"{% endif %}>
               <div class="pull-right btn-group">
-                <a data-nodrag ng-click="startEditing(this)" class="btn btn-default btn-sm" ng-class="{'active': editing}"><span title="{{ 'topics.btn.edit'|trans }}" class="glyphicon glyphicon-pencil"></span></a>
-                <a data-nodrag ng-click="showNewSubtopicBox(this)" class="btn btn-default btn-sm" ng-class="{'active': addingSubtopic}"><span title="{{ 'topics.label.addsubtopic'|trans }}" class="glyphicon glyphicon-plus"></span></a>
+                <a data-nodrag ng-click="treeCtrl.startEditing(this)" class="btn btn-default btn-sm" ng-class="{'active': treeCtrl.editing}"><span title="{{ 'topics.btn.edit'|trans }}" class="glyphicon glyphicon-pencil"></span></a>
+                <a data-nodrag ng-click="treeCtrl.showNewSubtopicBox(this)" class="btn btn-default btn-sm" ng-class="{'active': addingSubtopic}"><span title="{{ 'topics.label.addsubtopic'|trans }}" class="glyphicon glyphicon-plus"></span></a>
                 {% if compactView == false %}
-                <a data-nodrag ng-click="removeTopicAlert(node.id)" data-toggle="modal" data-target="#removeAlert" class="btn btn-default btn-sm"><span title="{{ 'topics.btn.remove'|trans }}" class="glyphicon glyphicon-trash"></span></a>
+                <a data-nodrag ng-click="treeCtrl.removeTopicAlert(node.id)" data-toggle="modal" data-target="#removeAlert" class="btn btn-default btn-sm"><span title="{{ 'topics.btn.remove'|trans }}" class="glyphicon glyphicon-trash"></span></a>
                 {% endif %}
               </div>
                 <div class="drag-bar" {% if compactView %}style="display: none;"{% endif %}></div>
-                <a data-nodrag ng-click="toggleTopic(this, node)" class="pointer"><span ng-if="node.__children.length > 0" class="glyphicon" ng-class="{'glyphicon-chevron-right': !collapsed, 'glyphicon-chevron-down': collapsed || node.hasAttachedSubtopic || showExpanded}"></span></a>
+                <a data-nodrag ng-click="toggle(this)" class="pointer"><span ng-if="node.__children.length > 0" class="glyphicon" ng-class="{'glyphicon-chevron-right': !collapsed || !treeCtrl.showExpanded || !toggler, 'glyphicon-chevron-down': collapsed || treeCtrl.showExpanded || toggler}"></span></a>
 
                 <div class="default-wrap" {% if not compactView %}ng-if="!editing"{% endif %}>
-                  {% if compactView %}<input type="checkbox" id="selectedCheckbox" checklist-model="selectedTopics.ids" checklist-value="node.id" class="topic-marker" />{% endif %}
-                  <span ng-bind-html="node.title | highlight:pattern | trust" class="ng-binding" {% if compactView %}style="margin-left: 20px;"{% endif %}></span>
-                  <ul ng-if="!editing" class="list-group" ng-model="node.translations" ng-init="setLanguageLabel(node, '{{ app.request.locale }}')">
-                      <li class="list-group-item" ng-class="{'active': node.activeLabel, 'fallback': languageCode != node.locale && !node.activeLabel && node.fallback}" ng-repeat="node in node.translations">
-                          <span class="badge ng-binding">{[{ node.locale }]}</span>
+                  {% if compactView %}<input type="checkbox" id="selectedCheckbox" checklist-model="treeCtrl.selectedTopics.ids" checklist-value="node.id" class="topic-marker" />{% endif %}
+                  <div><span ng-bind-html="node.title | highlight:treeCtrl.pattern | trust" class="ng-binding" {% if compactView %}style="margin-left: 20px;"{% endif %}></span>
+                  <ul ng-if="!editing" class="list-group" ng-model="node.translations">
+                      <li class="list-group-item" ng-class="{'active': node.activeLabel, 'fallback': treeCtrl.languageCode != node.locale && !node.activeLabel && node.fallback}" ng-repeat="node in node.translations track by node.id">
+                          <span class="badge ng-binding">{[{ ::node.locale }]}</span>
                       </li>
-                  </ul>
+                  </ul></div>
                 </div>
                 <div class="node-add-subtopic-div" ng-if="addingSubtopic" data-nodrag style="cursor:auto">
                 <h3>{{ 'topics.label.addsubtopic'|trans }}</h3>
@@ -120,7 +136,7 @@
                           <div class="alert alert-danger" ng-show="addSubTopicForm.title.$error.minlength" role="alert">{{ 'topics.tooshort'|trans }}</div>
                           <div class="form-group">
                             <input type="text" name="title" required ng-minlength="1" ng-maxlength="60" class="form-control input-sm" ng-model="node.newChild[node.id]" placeholder="{{ 'topics.label.subtopicname'|trans }}">
-                            <button type="submit" ng-disabled="addSubTopicForm.$invalid" class="btn btn-sm btn-default" ng-click="addNewTopic(this)">{{ 'topics.btn.add'|trans }}</button>
+                            <button type="submit" ng-disabled="addSubTopicForm.$invalid" class="btn btn-sm btn-default" ng-click="treeCtrl.addNewTopic(this)">{{ 'topics.btn.add'|trans }}</button>
                           </div>
                         </form>
                     </div>
@@ -132,7 +148,7 @@
                       <div class="alert alert-danger" ng-show="editTopicForm.title.$error.maxlength" role="alert">{{ 'topics.toolong'|trans }}</div>
                       <div class="alert alert-danger" ng-show="editTopicForm.title.$error.minlength" role="alert">{{ 'topics.tooshort'|trans }}</div>
                         <input type="text" name="title" required ng-minlength="1" ng-maxlength="60" class="form-control input-sm" placeholder="{{ 'topics.label.topicname'|trans }}" ng-model="node.title">
-                      <button type="submit" ng-disabled="editTopicForm.$invalid" class="btn btn-sm btn-default" ng-click="updateTopic(node)">{{ 'topics.btn.save'|trans }}</button>
+                      <button type="submit" ng-disabled="editTopicForm.$invalid" class="btn btn-sm btn-default" ng-click="treeCtrl.updateTopic(node)">{{ 'topics.btn.save'|trans }}</button>
                     </form>
                   </div>
                 </div>
@@ -142,37 +158,37 @@
                             <div class="alert alert-danger" ng-show="addTranslationForm.title.$error.maxlength" role="alert">{{ 'topics.toolong'|trans }}</div>
                             <div class="alert alert-danger" ng-show="addTranslationForm.title.$error.minlength" role="alert">{{ 'topics.tooshort'|trans }}</div>
                             <div class="form-group">
-                              <select ng-model="languageSelected" ng-options="language.name for language in languageList" ng-change="onLanguageChange(languageSelected)" class="form-control input-sm" style="width: 160px" required>
+                              <select ng-model="treeCtrl.languageSelected" ng-options="language.name for language in treeCtrl.languageList" ng-change="treeCtrl.onLanguageChange(treeCtrl.languageSelected)" class="form-control input-sm" style="width: 160px" required>
                                 <option value="">{{ 'topics.label.choose'|trans }}</option>
                               </select>
                               <input type="text" name="title" required ng-minlength="1" ng-maxlength="60" class="form-control input-sm" ng-model="node.newTranslation[node.id]" placeholder="{{ 'topics.label.translationstring'|trans }}">
-                              <button type="submit" ng-disabled="addTranslationForm.$invalid" class="btn btn-sm btn-default" ng-click="addTranslation(node)">{{ 'topics.btn.add'|trans }}</button>
+                              <button type="submit" ng-disabled="addTranslationForm.$invalid" class="btn btn-sm btn-default" ng-click="treeCtrl.addTranslation(node)">{{ 'topics.btn.add'|trans }}</button>
                             </div>
                       </form>
                       <h3>{{ 'topics.label.topictranslations'|trans }}</h3>
                       <ul class="lang-list" ng-model="node.translations">
-                          <li ng-repeat="node in node.translations">
+                          <li ng-repeat="node in node.translations track by node.id">
                             <div>
-                              <span class="badge">{[{ node.locale }]}</span>
-                              {[{ node.content }]}
-                              <a data-nodrag class="remove-translation" ng-click="removeTranslation(node.id)"><span title="{{ 'topics.btn.removetrans'|trans }}" class="glyphicon glyphicon-remove"></span></a>
+                              <span class="badge">{[{ ::node.locale }]}</span>
+                              {[{ ::node.content }]}
+                              <a data-nodrag class="remove-translation" ng-click="treeCtrl.removeTranslation(node.id)"><span title="{{ 'topics.btn.removetrans'|trans }}" class="glyphicon glyphicon-remove"></span></a>
                             </div>
                           </li>
                       </ul>
                 </div>
                 <div class="button-close" ng-show="editing || addingSubtopic">
-                  <a class="btn btn-sm btn-default" data-nodrag ng-click="hideExtraOptions(this)"><span title="{{ 'topics.btn.hide'|trans }}" class="glyphicon glyphicon-chevron-up"></span></a>
+                  <a class="btn btn-sm btn-default" data-nodrag ng-click="treeCtrl.hideExtraOptions(this)"><span title="{{ 'topics.btn.hide'|trans }}" class="glyphicon glyphicon-chevron-up"></span></a>
                 </div>
               </div>
-              <ol ui-tree-nodes ng-model="node.__children" ng-class="{hidden: !showExpanded && !collapsed && !pattern && !node.hasAttachedSubtopic }" ng-if="collapsed || node.hasAttachedSubtopic || ex">
-                  <li ng-repeat="node in node.__children" ui-tree-node ng-include="'nodes_renderer.html'">
+              <ol ui-tree-nodes ng-model="node.__children" ng-if="collapsed || treeCtrl.showExpanded || toggler">
+                  <li ng-repeat="node in node.__children" id="node{[{::node.id}]}" ng-if="treeCtrl.treeFilter(node, treeCtrl.pattern, treeCtrl.supportedFields, this) && !dim" ui-tree-node ng-include="'nodes_renderer.html'">
 
                   </li>
               </ol>
             </script>
-            <div ui-tree="treeOptions" {% if compactView %}data-drag-enabled="false"{% endif %} id="tree-root">
-              <ol ui-tree-nodes ng-model="data">
-                <li ng-repeat="node in data" ui-tree-node ng-include="'nodes_renderer.html'" ng-hide="!treeFilter(node, pattern, supportedFields, this) && !dim" ng-class="{'filtered-out':!treeFilter(node, pattern, supportedFields, this) && dim}"></li>
+            <div ui-tree="treeCtrl.treeOptions" {% if compactView %}data-drag-enabled="false"{% endif %} id="tree-root">
+              <ol ui-tree-nodes ng-model="treeCtrl.data">
+                <li ng-repeat="node in treeCtrl.data track by node.id" id="node{[{::node.id}]}" ui-tree-node ng-include="'nodes_renderer.html'" ng-hide="treeCtrl.pattern && !treeCtrl.treeFilter(node, treeCtrl.pattern, treeCtrl.supportedFields, this) && !dim"></li>
               </ol>
             </div>
             <!-- Modal -->
@@ -190,7 +206,7 @@
                   </div>
                   <div class="modal-footer">
                     <button type="button" class="btn btn-default" data-dismiss="modal">{{ 'topics.btn.close'|trans }}</button>
-                    <button type="button" ng-click="removeTopic()" ng-disabled="deleteDisabled" class="btn btn-danger">{{ 'topics.btn.remove'|trans }}</button>
+                    <button type="button" ng-click="treeCtrl.removeTopic()" ng-disabled="treeCtrl.deleteDisabled" class="btn btn-danger">{{ 'topics.btn.remove'|trans }}</button>
                   </div>
                 </div>
               </div>
@@ -208,4 +224,3 @@
     {{ parent() }}
   {% endif %}
 {% endblock %}
-

--- a/newscoop/src/Newscoop/NewscoopBundle/Services/TopicService.php
+++ b/newscoop/src/Newscoop/NewscoopBundle/Services/TopicService.php
@@ -5,7 +5,6 @@
  * @copyright 2014 Sourcefabric z.ú.
  * @license http://www.gnu.org/licenses/gpl-3.0.txt
  */
-
 namespace Newscoop\NewscoopBundle\Services;
 
 use Newscoop\NewscoopBundle\Entity\Topic;
@@ -14,6 +13,7 @@ use Doctrine\ORM\EntityManager;
 use Newscoop\Exception\ResourcesConflictException;
 use Doctrine\ORM\Query;
 use Newscoop\EventDispatcher\Events\GenericEvent;
+use Newscoop\NewscoopBundle\Entity\TopicTranslation;
 
 /**
  * Topcis service.
@@ -297,6 +297,8 @@ class TopicService
             $node->setOrder((int) $maxOrderValue + 1);
         }
 
+        $node->addTranslation(new TopicTranslation($locale ?: $node->getTranslatableLocale(), 'title', $node->getTitle(), true));
+
         $this->em->persist($node);
         $metadata = $this->em->getClassMetaData(get_class($node));
         $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_NONE);
@@ -419,7 +421,7 @@ class TopicService
 
         return array(
             'name' => $name,
-            'locale' => $languageCode
+            'locale' => $languageCode,
         );
     }
 
@@ -435,7 +437,6 @@ class TopicService
      */
     public function getTopicBy($string, $locale = null)
     {
-
         $topic = $this->getTopicRepository()
             ->getTopicByIdOrName($string, $locale)
             ->getOneOrNullResult();
@@ -549,6 +550,7 @@ class TopicService
         $this->removeTopicFromAllUsers($topic->getId());
         $this->em->remove($topic);
         $this->em->flush();
+        $this->em->clear();
 
         return true;
     }

--- a/spec/Newscoop/GimmeBundle/Controller/TopicsControllerSpec.php
+++ b/spec/Newscoop/GimmeBundle/Controller/TopicsControllerSpec.php
@@ -189,7 +189,8 @@ class TopicsControllerSpec extends ObjectBehavior
             'id' => 1,
         ))->willReturn($topic);
 
-        $topicService->deleteTopic($topic)->willReturn(true);
+        $topicService->deleteTopic($topic)->shouldBeCalled();
+
         $response = $this->deleteTopicAction($request, 1);
         $response->shouldHaveType('Symfony\Component\HttpFoundation\Response');
         $response->getStatusCode()->shouldReturn(204);


### PR DESCRIPTION
**Important changes:**
- in article edit screen when editing article's attached topics, on top of the iframe, there is a list of all attached topics for given article. Each attached topic is listed with the full path it has in the tree. When clicking on the attached topic, you will be moved to the position where this topic is located in the tree, so you can edit it, add new subtopic to it etc.
- when searching for the topic (search input), only the current "subtree" will be shown and expanded in which is found the topic of the given phrase in a search input. Other topics will be invisible in this situation, so editors can easly spot the topic in the tree and will not need to scroll down the whole tree.
- performance improvements