### PR TITLE
[wip] - AZ-266: Adds return status to webcode command and removes weird loop

### DIFF
--- a/newscoop/library/Newscoop/Tools/Console/Command/GenerateWebcodeCommand.php
+++ b/newscoop/library/Newscoop/Tools/Console/Command/GenerateWebcodeCommand.php
@@ -98,8 +98,10 @@ class GenerateWebcodeCommand extends Console\Command\Command
             }
 
             $output->writeln('<info>Webcodes generated successfully!</info>');
+            return 0;
         } catch (\Exception $e) {
             $output->writeln('<error>'.$e->getMessage().'</error>');
+            return 1;
         }
     }
 

--- a/newscoop/library/Newscoop/WebcodeFacade.php
+++ b/newscoop/library/Newscoop/WebcodeFacade.php
@@ -93,11 +93,7 @@ class WebcodeFacade
      */
     private function generateWebcode()
     {
-        for ($length = 5; $length < 10; $length++) {
-            for ($i = 0; $i < 10; $i++) {
-                return $this->random->getRandomString(5);
-            }
-        }
+        return $this->random->getRandomString(5);
     }
 
     /**


### PR DESCRIPTION
Optimizes the generation of webcodes by removing some weird loop. 
Also adds return status to the webcode command, this way its output can 
be properly used in bash scripts.