### PR TITLE
AZ-266: Add script to run webcode for many many webcodes

### DIFF
--- a/newscoop/bin/webcode_generate_all.sh
+++ b/newscoop/bin/webcode_generate_all.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+echo "Clears all webcodes first, then generates webcodes for all articles with autorestart on errors."
+echo "Starting in 5 seconds. Press ^C to cancel."
+
+sleep 5
+
+php application/console webcode:generate --only-clear
+
+until php application/console webcode:generate; do
+    echo "Webcode generation stopped on error with code $?. Automatically restarting..." >&2
+    sleep 2
+done
+
+echo "Webcode generation done."
+
+exit 0

--- a/newscoop/library/Newscoop/Tools/Console/Command/GenerateWebcodeCommand.php
+++ b/newscoop/library/Newscoop/Tools/Console/Command/GenerateWebcodeCommand.php
@@ -26,9 +26,10 @@ class GenerateWebcodeCommand extends Console\Command\Command
     {
         $this
             ->setName('webcode:generate')
-            ->setDescription('Generates webcodes for articles without it.')
+            ->setDescription('Generate webcodes for articles without webcode. It\'s always safe to run the command without the clear parameters.')
             ->addArgument('number', InputArgument::OPTIONAL, 'Article number range to start from, e.g. 300', 1)
-            ->addOption('clear', null, InputOption::VALUE_NONE, 'If set, clears indexes. Use this first time.');
+            ->addOption('clear', null, InputOption::VALUE_NONE, 'If set, clears webcodes and starts generating webcodes afterards. Use this the first time.')
+            ->addOption('only-clear', null, InputOption::VALUE_NONE, 'If set, clears webcodes. Doesn\'t start generation.');
     }
 
     /**
@@ -44,7 +45,7 @@ class GenerateWebcodeCommand extends Console\Command\Command
         try {
             ini_set('memory_limit', '-1');
 
-            if ($input->getOption('clear')) {
+            if ($input->getOption('clear') || $input->getOption('only-clear')) {
                 $output->writeln('<info>Clearing webcodes.</info>');
 
                 $qb = $em->createQueryBuilder();
@@ -61,6 +62,9 @@ class GenerateWebcodeCommand extends Console\Command\Command
                     ->execute();
 
                 $output->writeln('<info>Webcodes cleared: '.$result.'.</info>');
+                if ($input->getOption('only-clear')) {
+                    return 0;
+                }
             }
 
             $output->writeln('<info>Generating webcodes. Please wait! It can take up to few minutes, depends on database size.</info>');
@@ -84,6 +88,7 @@ class GenerateWebcodeCommand extends Console\Command\Command
                 $articles = $em->getRepository('Newscoop\Entity\Article')
                     ->createQueryBuilder('a')
                     ->where('a.webcode IS NULL')
+                    ->orderBy('a.number', 'ASC')
                     ->setFirstResult($offset)
                     ->setMaxResults($batch)
                     ->getQuery()

--- a/newscoop/library/Newscoop/Tools/Console/Command/GenerateWebcodeCommand.php
+++ b/newscoop/library/Newscoop/Tools/Console/Command/GenerateWebcodeCommand.php
@@ -28,7 +28,7 @@ class GenerateWebcodeCommand extends Console\Command\Command
             ->setName('webcode:generate')
             ->setDescription('Generate webcodes for articles without webcode. It\'s always safe to run the command without the clear parameters.')
             ->addArgument('number', InputArgument::OPTIONAL, 'Article number range to start from, e.g. 300', 1)
-            ->addOption('clear', null, InputOption::VALUE_NONE, 'If set, clears webcodes and starts generating webcodes afterards. Use this the first time.')
+            ->addOption('clear', null, InputOption::VALUE_NONE, 'If set, clears webcodes and starts generating webcodes afterwards. Use this the first time.')
             ->addOption('only-clear', null, InputOption::VALUE_NONE, 'If set, clears webcodes. Doesn\'t start generation.');
     }
 

--- a/newscoop/library/Newscoop/WebcodeFacade.php
+++ b/newscoop/library/Newscoop/WebcodeFacade.php
@@ -46,7 +46,8 @@ class WebcodeFacade
     {
         if (empty($webcode)) {
             $webcode = $this->generateWebcode();
-        } else if (!$this->isUnique($webcode)) {
+        }
+        if (!$this->isUnique($webcode)) {
             throw new \InvalidArgumentException("Webcode '$webcode' is in use.");
         }
 


### PR DESCRIPTION
Sometimes the webcode generator generates a duplicate. The default webcode
    command will terminate with status 1. By using the provided
    webcode_generate_all.sh shell script it will keep running the webcode
    generate command untill the script exits with status 0.