### PR TITLE
CS-5942: Adds check if request is set

### DIFF
--- a/newscoop/library/Newscoop/Services/ThemesService.php
+++ b/newscoop/library/Newscoop/Services/ThemesService.php
@@ -68,8 +68,11 @@ class ThemesService implements ThemesServiceInterface
      */
     public function getThemePath($language = null)
     {
+        $frontpage = false;
         $publicationMetadata = $this->publicationService->getPublicationMetadata();
-        $frontpage = $this->isHomepage($publicationMetadata['request']['uri'], true);
+        if (isset($publicationMetadata['request'])) {
+            $frontpage = $this->isHomepage($publicationMetadata['request']['uri'], true);
+        }
         $languageId = null;
         $issue = $this->issueService->getIssue();
         if (!$issue) {


### PR DESCRIPTION
This would trigger PHP Notices when running newscoop-backup and
newscoop-restore.