### PR TITLE
CS-5933: Forces getSEO() always to return an array and fixes typo

### DIFF
--- a/newscoop/classes/Publication.php
+++ b/newscoop/classes/Publication.php
@@ -269,7 +269,7 @@ class Publication extends DatabaseObject {
      */
     public function getSeo()
     {
-        return @unserialize($this->m_data['seo']);
+        return (array) @unserialize($this->m_data['seo']);
     } // fn getSeo
 
 

--- a/newscoop/library/Newscoop/Entity/Publication.php
+++ b/newscoop/library/Newscoop/Entity/Publication.php
@@ -141,7 +141,7 @@ class Publication
 
     /**
      * @ORM\Column(nullable=True)
-     * @var int
+     * @var string
      */
     protected $seo;
 


### PR DESCRIPTION
The getSeo() method on the entity for Publication also type casts any
returned value from unserialize to an array, therefore getSEO() in the
legacy classes should do the same.
Plus the data type should be string, not int.