### PR TITLE
CS-5941: Sets different content-type for rss.tpl or atom.tpl templates

### DIFF
--- a/newscoop/template_engine/classes/CampHTMLDocument.php
+++ b/newscoop/template_engine/classes/CampHTMLDocument.php
@@ -311,6 +311,13 @@ final class CampHTMLDocument
             }
         }
 
+        if (strpos($template, 'rss.tpl') !== false) {
+            $this->setMimeType('application/rss+xml');
+        }
+        if (strpos($template, 'atom.tpl') !== false) {
+            $this->setMimeType('application/atom+xml');
+        }
+
         try {
             $tpl->display($template);
         } catch (\Exception $e) {

--- a/newscoop/template_engine/classes/CampSite.php
+++ b/newscoop/template_engine/classes/CampSite.php
@@ -154,7 +154,10 @@ final class CampSite extends CampSystem
         $document->render($params);
 
         if (array_key_exists('controller', $GLOBALS)) {
-            $GLOBALS['controller']->getResponse()->setHeader('Content-Type', $document->getMimeType());
+            $GLOBALS['controller']->getResponse()->setHeader(
+                'Content-Type',
+                sprintf('%s; charset=%s', $document->getMimeType(), $document->getCharset())
+            );
             $GLOBALS['header_content_type_set'] = true;
         }
     }// fn render

--- a/newscoop/template_engine/classes/CampSite.php
+++ b/newscoop/template_engine/classes/CampSite.php
@@ -152,6 +152,11 @@ final class CampSite extends CampSystem
             'error_message' => isset($error_message) ? $error_message : null
         );
         $document->render($params);
+
+        if (array_key_exists('controller', $GLOBALS)) {
+            $GLOBALS['controller']->getResponse()->setHeader('Content-Type', $document->getMimeType());
+            $GLOBALS['header_content_type_set'] = true;
+        }
     }// fn render
 
     /**


### PR DESCRIPTION
This allows us to add as many rss or atom templates as we want. The only requirement is that they end with _rss.tpl_ or _atom.tpl_. Then the corresponding content-types will be set.