### PR TITLE
ignore comments for not existing articles

### DIFF
--- a/newscoop/src/Newscoop/NewscoopBundle/Controller/CommentsController.php
+++ b/newscoop/src/Newscoop/NewscoopBundle/Controller/CommentsController.php
@@ -489,6 +489,10 @@ class CommentsController extends Controller
             foreach ($pagination as $comment) {
                 $comment = $comment[0];
                 $thread = $em->getRepository('Newscoop\Entity\Article')->findOneBy(array('number' => $comment->getThread()));
+                if (!$thread) {
+                    continue;
+                }
+
                 $threadSection = $thread->getSection();
 
                 if (!$threadSection) {


### PR DESCRIPTION
If an article doesnt exist in the database (deleted manually, comments were imported and articles for these comments dont exist etc), comments should be ignored in that case so it wont throw an exception and will not disable the comments management page.