### PR TITLE
CS-5931: connects symfony locale to legacy locale

### DIFF
--- a/newscoop/application/controllers/helpers/Smarty.php
+++ b/newscoop/application/controllers/helpers/Smarty.php
@@ -24,6 +24,13 @@ class Action_Helper_Smarty extends Zend_Controller_Action_Helper_Abstract
 
         $request = $this->getRequest();
 
+        if ($request->getParam('language') == false) {
+            $locale = \Zend_Controller_Front::getInstance()->getParam('locale');
+            if (!empty($locale)) {
+                $request->setParam('language', $locale);
+            }
+        }
+
         $format = $request->getParam('format', null);
         if (isset($format) && $format == "json") {
             return;

--- a/newscoop/library/Newscoop/SmartyView.php
+++ b/newscoop/library/Newscoop/SmartyView.php
@@ -30,8 +30,19 @@ class SmartyView extends \Zend_View_Abstract
             $this->smarty->assign($key, $val);
         }
 
+        $context = $this->smarty->context();
+        $locale = \Zend_Controller_Front::getInstance()->getParam('locale');
+        $em = \Zend_Registry::get('container')->getService('em');
+        try {
+            $language = $em->getRepository('Newscoop\Entity\Language')
+                ->findOneByCode($locale);
+            $context->language = new \MetaLanguage($language->getId());
+        } catch (\Exception $e) {
+            // Do nothing, default language will be used
+        }
+
         $this->smarty->assign('view', $this);
-        $this->smarty->assign('gimme', $this->smarty->context());
+        $this->smarty->assign('gimme', $context);
 
         $file = array_shift(func_get_args());
         $this->smarty->display($file);

--- a/newscoop/library/Newscoop/SmartyView.php
+++ b/newscoop/library/Newscoop/SmartyView.php
@@ -30,19 +30,8 @@ class SmartyView extends \Zend_View_Abstract
             $this->smarty->assign($key, $val);
         }
 
-        $context = $this->smarty->context();
-        $locale = \Zend_Controller_Front::getInstance()->getParam('locale');
-        $em = \Zend_Registry::get('container')->getService('em');
-        try {
-            $language = $em->getRepository('Newscoop\Entity\Language')
-                ->findOneByCode($locale);
-            $context->language = new \MetaLanguage($language->getId());
-        } catch (\Exception $e) {
-            // Do nothing, default language will be used
-        }
-
         $this->smarty->assign('view', $this);
-        $this->smarty->assign('gimme', $context);
+        $this->smarty->assign('gimme', $this->smarty->context());
 
         $file = array_shift(func_get_args());
         $this->smarty->display($file);

--- a/newscoop/src/Newscoop/ZendBridgeBundle/Controller/BridgeController.php
+++ b/newscoop/src/Newscoop/ZendBridgeBundle/Controller/BridgeController.php
@@ -55,6 +55,7 @@ class BridgeController extends Controller
         }
 
         $front->setParam('bootstrap', $bootstrap);
+        $front->setParam('locale', $request->getLocale());
         $front->setBaseUrl('/');
         $response = $front->dispatch();
 


### PR DESCRIPTION
This has my preference over https://github.com/sourcefabric/Newscoop/pull/1314 because it just sets the language for the internal request and then caching is also handled etc etc.