### PR TITLE
CS-5923 - After upgrade: fatal error on article editor opening due to…

### DIFF
--- a/newscoop/install/Resources/sql/campsite_core.sql
+++ b/newscoop/install/Resources/sql/campsite_core.sql
@@ -1780,7 +1780,9 @@ UNLOCK TABLES;
 -- Table structure for table `main_topics`
 --
 
-CREATE TABLE IF NOT EXISTS `main_topics` (
+DROP TABLE IF EXISTS `main_topics`;
+
+CREATE TABLE `main_topics` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `parent_id` int(11) DEFAULT NULL,
   `title` varchar(64) COLLATE utf8_unicode_ci NOT NULL,
@@ -1802,7 +1804,9 @@ ALTER TABLE `main_topics` ADD CONSTRAINT `FK_EEAFE2F727ACA70` FOREIGN KEY (`pare
 -- Table structure for table `topic_translations`
 --
 
-CREATE TABLE IF NOT EXISTS `topic_translations` (
+DROP TABLE IF EXISTS `topic_translations`;
+
+CREATE TABLE `topic_translations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `object_id` int(11) DEFAULT NULL,
   `locale` varchar(8) COLLATE utf8_unicode_ci NOT NULL,

--- a/newscoop/install/Resources/sql/upgrade/4.4.x/2014.12.02/tables.sql
+++ b/newscoop/install/Resources/sql/upgrade/4.4.x/2014.12.02/tables.sql
@@ -1,4 +1,6 @@
-CREATE TABLE IF NOT EXISTS `main_topics` (
+DROP TABLE IF EXISTS `topic_translations`;
+DROP TABLE IF EXISTS `main_topics`;
+CREATE TABLE `main_topics` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `parent_id` int(11) DEFAULT NULL,
   `title` varchar(64) COLLATE utf8_unicode_ci NOT NULL,
@@ -14,7 +16,7 @@ CREATE TABLE IF NOT EXISTS `main_topics` (
   KEY `IDX_EEAFE2F727ACA70` (`parent_id`),
   CONSTRAINT `FK_EEAFE2F727ACA70` FOREIGN KEY (`parent_id`) REFERENCES `main_topics` (`id`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;
-CREATE TABLE IF NOT EXISTS `topic_translations` (
+CREATE TABLE `topic_translations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `object_id` int(11) DEFAULT NULL,
   `locale` varchar(8) COLLATE utf8_unicode_ci NOT NULL,

--- a/newscoop/install/Resources/sql/upgrade/4.4.x/2015.03.11/topics.php
+++ b/newscoop/install/Resources/sql/upgrade/4.4.x/2015.03.11/topics.php
@@ -64,7 +64,7 @@ $app['topics_service'] = $app->share(function () use ($app) {
 try {
     $app['db']->query('ALTER TABLE `topic_translations` ADD `isDefault` INT( 1 ) NULL DEFAULT NULL');
 } catch (\Exception $e) {
-    if ($app['db']->errorCode() !== '42000') {
+    if ($app['db']->errorCode() !== '42S21') {
         $logger->addWarning($e->getMessage());
     }
 }

--- a/newscoop/install/Resources/sql/upgrade/4.4.x/2015.10.15/topic_translations.php
+++ b/newscoop/install/Resources/sql/upgrade/4.4.x/2015.10.15/topic_translations.php
@@ -32,7 +32,7 @@ $app->register(new Silex\Provider\DoctrineServiceProvider(), array(
 try {
     $app['db']->query('ALTER TABLE `topic_translations` ADD `isDefault` INT( 1 ) NULL DEFAULT NULL');
 } catch (\Exception $e) {
-    if ($app['db']->errorCode() !== '42000') {
+    if ($app['db']->errorCode() !== '42S21') {
         $upgradeErrors[] = $e->getMessage();
         $logger->addError($e->getMessage());
     }


### PR DESCRIPTION
… topic stuff

in case there are some topics inserted (e.g. when someone upgraded from 4.3.2 to 4.4.x
and restored back to 4.3.2 for some reason, there was a bug that the main_topics and topic_translations
tables were not dropped by restore script. Then when upgrading again to some 4.4.x version, this script: topics.php didnt insert all topics properly, thus it caused etnity not found issues because some topics were missing)