### PR TITLE
fix(profile form): add location to Profile and User forms

### DIFF
--- a/newscoop/application/forms/Profile.php
+++ b/newscoop/application/forms/Profile.php
@@ -105,8 +105,8 @@ class Application_Form_Profile extends Zend_Form
             'label' => $translator->trans('Allow sending emails', array(), 'users'),
         ));
 
-        $profile->addElement('text', 'custom_attr_1', array(
-            'label' => $translator->trans('Custom Attr 1', array(), 'users'),
+        $profile->addElement('text', 'location', array(
+            'label' => $translator->trans('Location', array(), 'users'),
             'filters' => array('stringTrim'),
         ));
 

--- a/newscoop/application/forms/Profile.php
+++ b/newscoop/application/forms/Profile.php
@@ -105,6 +105,11 @@ class Application_Form_Profile extends Zend_Form
             'label' => $translator->trans('Allow sending emails', array(), 'users'),
         ));
 
+        $profile->addElement('text', 'custom_attr_1', array(
+            'label' => $translator->trans('Custom Attr 1', array(), 'users'),
+            'filters' => array('stringTrim'),
+        ));
+
         $this->addSubForm($profile, 'attributes');
 
         $this->addElement('submit', 'submit', array(

--- a/newscoop/application/modules/admin/forms/User.php
+++ b/newscoop/application/modules/admin/forms/User.php
@@ -148,6 +148,11 @@ class Admin_Form_User extends Zend_Form
             'filters' => array('stringTrim'),
         ));
 
+        $profile->addElement('text', 'location', array(
+            'label' => $translator->trans('Location', array(), 'users'),
+            'filters' => array('stringTrim'),
+        ));
+
         $this->addSubForm($profile, 'attributes');
 
         $this->addElement('multiCheckbox', 'user_type', array(

--- a/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/users.en.yml
+++ b/newscoop/src/Newscoop/NewscoopBundle/Resources/translations/users.en.yml
@@ -188,6 +188,7 @@ Miscellaneous: Miscellaneous
 'User account is highlighted as "featured account"': 'User account is highlighted as "featured account"'
 'Custom attribute...': 'Custom attribute...'
 'An author with the same full name (combination of first and last name) already exists.': 'An author with the same full name (combination of first and last name) already exists.'
+Location: Location
 
 users:
     label:


### PR DESCRIPTION
this is required for zentralplus-reloaded, but also might be useful for other projects.  However, if there is  another way to set the custom_attr_1 user field from frontend templates, specifically from the dashboard_index.tpl (which uses the application/forms/Profile.php form), and one that does NOT require core changes, then please let me know, and feel free to close this PR.