### PR TITLE
Logout redirection, redirect routes fixes, AuthController improvements

### DIFF
--- a/newscoop/application/controllers/AuthController.php
+++ b/newscoop/application/controllers/AuthController.php
@@ -21,7 +21,7 @@ class AuthController extends Zend_Controller_Action
     public function indexAction()
     {
         if ($this->auth->hasIdentity()) {
-            $this->_helper->redirector('index', 'index');
+            $this->_helper->redirector('index', 'dashboard');
         }
 
         $translator = Zend_Registry::get('container')->getService('translator');
@@ -170,23 +170,23 @@ class AuthController extends Zend_Controller_Action
         $user = $this->_helper->service('user')->find($this->_getParam('user'));
         if (empty($user)) {
             $this->_helper->flashMessenger(array('error', $translator->trans('User not found.')));
-            $this->_helper->redirector('index', 'index', 'default');
+            $this->_helper->redirector('password-restore', 'auth');
         }
 
         if (!$user->isActive()) {
             $this->_helper->flashMessenger(array('error', $translator->trans('User is not active user.')));
-            $this->_helper->redirector('index', 'index', 'default');
+            $this->_helper->redirector('password-restore', 'auth');
         }
 
         $token = $this->_getParam('token', false);
         if (!$token) {
             $this->_helper->flashMessenger(array('error', $translator->trans('No token provided.')));
-            $this->_helper->redirector('index', 'index', 'default');
+            $this->_helper->redirector('password-restore', 'auth');
         }
 
         if (!$this->_helper->service('user.token')->checkToken($user, $token, 'password.restore')) {
             $this->_helper->flashMessenger(array('error', $translator->trans('Invalid token.')));
-            $this->_helper->redirector('index', 'index', 'default');
+            $this->_helper->redirector('password-restore', 'auth');
         }
 
         $form = new Application_Form_PasswordRestorePassword();

--- a/newscoop/application/controllers/AuthController.php
+++ b/newscoop/application/controllers/AuthController.php
@@ -51,21 +51,6 @@ class AuthController extends Zend_Controller_Action
         return $authenticationException;
     }
 
-    public function logoutAction()
-    {
-        if ($this->auth->hasIdentity()) {
-            $this->auth->clearIdentity();
-        }
-
-        setcookie('NO_CACHE', 'NO', time()-3600, '/', '.'.$this->extractDomain($_SERVER['HTTP_HOST']));
-        $url = $this->_getParam('url');
-        if (!is_null($url)) {
-            $this->_redirect($url);
-        }
-
-        $this->_helper->redirector->gotoUrl('?t='.time());
-    }
-
     public function socialAction()
     {
         $preferencesService = \Zend_Registry::get('container')->getService('system_preferences_service');

--- a/newscoop/src/Newscoop/NewscoopBundle/Security/Http/Authentication/FrontendLogoutSuccessHandler.php
+++ b/newscoop/src/Newscoop/NewscoopBundle/Security/Http/Authentication/FrontendLogoutSuccessHandler.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * @package Newscoop\NewscoopBundle
  * @author Rafał Muszyński <rafal.muszynski@sourcefabric.org>
  * @copyright 2014 Sourcefabric o.p.s.
  * @license http://www.gnu.org/licenses/gpl-3.0.txt
  */
+
 namespace Newscoop\NewscoopBundle\Security\Http\Authentication;
 
 use Symfony\Component\HttpFoundation\Request;
@@ -12,7 +12,7 @@ use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 
 /**
- * Custom authentication success handler
+ * Custom authentication success handler.
  */
 class FrontendLogoutSuccessHandler extends AbstractLogoutHandler
 {
@@ -37,7 +37,7 @@ class FrontendLogoutSuccessHandler extends AbstractLogoutHandler
      */
     public function onLogoutSuccess(Request $request)
     {
-        $this->setTargetUrl($request);
+        $this->targetUrl = $request->query->get('_target_path', $request->query->get('url', $this->targetUrl));
         $zendAuth = \Zend_Auth::getInstance();
         $zendAuth->clearIdentity();
         // logout from OAuth
@@ -50,16 +50,5 @@ class FrontendLogoutSuccessHandler extends AbstractLogoutHandler
         $this->unsetNoCacheCookie($request);
 
         return parent::onLogoutSuccess($request);
-    }
-
-    private function setTargetUrl(Request $request)
-    {
-        if ($request->query->has('url')) {
-            $this->targetUrl = $request->query->get('url');
-        }
-
-        if ($request->query->has('_target_path')) {
-            $this->targetUrl = $request->query->get('_target_path');
-        }
     }
 }

--- a/newscoop/src/Newscoop/NewscoopBundle/Security/Http/Authentication/FrontendLogoutSuccessHandler.php
+++ b/newscoop/src/Newscoop/NewscoopBundle/Security/Http/Authentication/FrontendLogoutSuccessHandler.php
@@ -37,6 +37,7 @@ class FrontendLogoutSuccessHandler extends AbstractLogoutHandler
      */
     public function onLogoutSuccess(Request $request)
     {
+        $this->setTargetUrl($request);
         $zendAuth = \Zend_Auth::getInstance();
         $zendAuth->clearIdentity();
         // logout from OAuth
@@ -49,5 +50,16 @@ class FrontendLogoutSuccessHandler extends AbstractLogoutHandler
         $this->unsetNoCacheCookie($request);
 
         return parent::onLogoutSuccess($request);
+    }
+
+    private function setTargetUrl(Request $request)
+    {
+        if ($request->query->has('url')) {
+            $this->targetUrl = $request->query->get('url');
+        }
+
+        if ($request->query->has('_target_path')) {
+            $this->targetUrl = $request->query->get('_target_path');
+        }
     }
 }


### PR DESCRIPTION
- [x] - all wrong redirects to `index` have been replaced in `AuthController` as `/index`route doesn't exist in Newscoop.
- [x] - removed `logoutAction` from `AuthController` as the logout is handled by Symfony firewall
- [x] - redirect user to target path / url after logout

**How does it work?**

You can provide two types of parameters: `url` and `_target_path`, the `url` query parameter is left for backward compability as we used that before in some newscoop versions and this feature was broken for some time already. Now in Newscoop we use all the time `_target_path` param, so I also added that.

example: http://example.com/auth/logout?url=/de/news/aktuell or http://example.com/auth/logout?_target_path=/de/news/aktuell

the above example will result with the same: it will redirect user to http://example.com/de/news/aktuell after logout.
