### PR TITLE
make  property public, as it's used in many places already and was public (not declared) before

### DIFF
--- a/newscoop/library/Newscoop/TemplateList/PaginatedBaseList.php
+++ b/newscoop/library/Newscoop/TemplateList/PaginatedBaseList.php
@@ -41,7 +41,7 @@ abstract class PaginatedBaseList extends BaseList
     /**
      * @var \Knp\Component\Pager\Pagination\PaginationInterface
      */
-    protected $pagination;
+    public $pagination;
 
     /**
      * @param \Newscoop\Criteria                  $criteria


### PR DESCRIPTION
Fixes issue with not working `{{ listpagination }}`. 
