### PR TITLE
MOTM-1818 - Add 'Stay logged in' to Frontend (cookie should be set to one week / compare old Setup)

### DIFF
--- a/newscoop/application/configs/parameters/parameters.yml
+++ b/newscoop/application/configs/parameters/parameters.yml
@@ -134,3 +134,4 @@ parameters:
         environment: 'prod'
     simple_security:
         users_file: "%application_path%/configs/security/users.json"
+    remember_me.lifetime: 31536000 # 1 year in seconds

--- a/newscoop/application/configs/symfony/security.yml
+++ b/newscoop/application/configs/symfony/security.yml
@@ -68,8 +68,8 @@ security:
                 check_path:  admin_login_check
                 success_handler: newscoop_newscoop.security.authentication.success_handler
             remember_me:
-                key: "changeme"
-                lifetime: 31536000
+                key: "%kernel.secret%"
+                lifetime: %remember_me.lifetime%
                 path: /
                 domain: ~
             logout:
@@ -88,8 +88,8 @@ security:
                 password_parameter: password
                 success_handler: newscoop_newscoop.security.authentication.frontend.success_handler
             remember_me:
-                key: "changeme"
-                lifetime: 31536000
+                key: "%kernel.secret%"
+                lifetime: %remember_me.lifetime%
                 path: /
                 domain: ~
             logout:


### PR DESCRIPTION
Added `remember_me.lifetime` parameter so it can be set to a custom value in `custom_parameters.yml` file. Currently, default logged in time for remember me functionality is 1 year, this should be customizable.

Also set the remember me key's value to `kernel.secret` parameter.
