### PR TITLE
remove not needed community ticker command

### DIFF
--- a/newscoop/library/Newscoop/Article/SearchService.php
+++ b/newscoop/library/Newscoop/Article/SearchService.php
@@ -217,7 +217,7 @@ class SearchService implements ServiceInterface
         }
     }
 
-    public function searchArticles($articleSearchCriteria, $onlyPublished = true)
+    public function searchArticles($articleSearchCriteria, $onlyPublished = true, $returnQuery = false)
     {
         $keywords = array_diff(explode(',', $articleSearchCriteria->query), array(''));
 
@@ -231,14 +231,17 @@ class SearchService implements ServiceInterface
             }
         }
 
-        $articles = $this->em->getRepository('Newscoop\Entity\Article')
+        $articlesQuery = $this->em->getRepository('Newscoop\Entity\Article')
             ->searchArticles(
                 $articleSearchCriteria,
                 $onlyPublished
-            )
-            ->getResult();
+            );
 
-        return $articles;
+        if (!$returnQuery) {
+           return $articlesQuery->getResult();
+        }
+
+        return $articlesQuery;
     }
 
     /**


### PR DESCRIPTION
Since version 4.3.0 we have moved community ticker from the plugin to the Newscoop core. The following command should be removed, because if you run it in Newscoop version >=4.3.0 it will delete the whole community_ticker_events table, thus the Newscoop will crash.
