### PR TITLE
Set requirement of previous session to false in the security config

### DIFF
--- a/newscoop/application/configs/symfony/security.yml
+++ b/newscoop/application/configs/symfony/security.yml
@@ -87,6 +87,7 @@ security:
                 username_parameter: email
                 password_parameter: password
                 success_handler: newscoop_newscoop.security.authentication.frontend.success_handler
+                require_previous_session: false
             remember_me:
                 key: "%kernel.secret%"
                 lifetime: %remember_me.lifetime%


### PR DESCRIPTION
There is no previous session when the front page, with the login form on it, is cached, which results in a SessionUnavailableException on line 142 of AbstractAuthenticationListener if the require_previous_session option is set to true, as it is by default.
