### PR TITLE
MOTM-2298 - Chief editors get system notifications even though checkb…

### DIFF
--- a/newscoop/library/Newscoop/Services/NotificationService.php
+++ b/newscoop/library/Newscoop/Services/NotificationService.php
@@ -30,8 +30,7 @@ class NotificationService
     const USER_DQL = "
         SELECT user.email
         FROM Newscoop\Entity\User user
-            JOIN user.groups group
-            JOIN group.role role
+            JOIN user.role role
             JOIN role.rules rule
         WHERE rule.type = :type
             AND rule.resource = :resource
@@ -67,7 +66,8 @@ class NotificationService
     public function findRecipients()
     {
         $emails = array_merge($this->findByGroup(), $this->findByUser());
-        return array_unique($emails);
+
+        return array_filter(array_unique($emails));
     }
 
     /**


### PR DESCRIPTION
…ox was deactivated in user permissions

If for example the user is in Administrator group, and the Notification permission is enabled for this group, user permissions should take precedence before group permissions, so the user can disable the notifications permission in his/her profile even if its enabled for the Administrator group which user is a member of.

In case the notification permission will be disabled for the group, and if enabled in user profile, user will recieve notifications. It applies to all permissions.
