### PR TITLE
Fix slideshow items order

### DIFF
--- a/newscoop/application/modules/admin/controllers/SlideshowController.php
+++ b/newscoop/application/modules/admin/controllers/SlideshowController.php
@@ -70,7 +70,8 @@ class Admin_SlideshowController extends Zend_Controller_Action
 
             if (!is_null($image) && $image !== "") {
                 try {
-                    $this->addItemToPackage(array_pop(explode('-', $image)), $slideshow);
+                    $item = explode('-', $image);
+                    $this->addItemToPackage(array_pop($item), $slideshow);
                 } catch (\InvalidArgumentException $e) {}
             }
 
@@ -114,7 +115,8 @@ class Admin_SlideshowController extends Zend_Controller_Action
         $translator = \Zend_Registry::get('container')->getService('translator');
         $slideshow = $this->getSlideshow();
         try {
-            $item = $this->addItemToPackage(array_pop(explode('-', $this->_getParam('image'))), $slideshow);
+            $item = explode('-', $this->_getParam('image'));
+            $item = $this->addItemToPackage(array_pop($item), $slideshow);
             $this->_helper->json(array(
                 'item' => $this->view->slideshowItem($item),
             ));
@@ -141,13 +143,7 @@ class Admin_SlideshowController extends Zend_Controller_Action
             $items[] = $this->view->slideshowItem($item);
         }
 
-        $offset = 0;
-        foreach ($slideshow->getItems() as $item) {
-            $item->setOffset($offset);
-            $offset++;
-        }
         $this->orm->flush();
-
         $this->_helper->json($items);
     }
 

--- a/newscoop/application/modules/admin/views/scripts/image/rendition.phtml
+++ b/newscoop/application/modules/admin/views/scripts/image/rendition.phtml
@@ -1,5 +1,5 @@
 <?php
-$translator = \Zend_Registry::get('container')->getService('translator'); 
+$translator = \Zend_Registry::get('container')->getService('translator');
 ?>
 <dl class="rendition">
     <dt>
@@ -16,7 +16,7 @@ $translator = \Zend_Registry::get('container')->getService('translator');
         </div>
     </dt>
     <dd class="name"><?php echo $this->escape($this->rendition->getLabel()); ?></dd>
-    <dd><small><?php echo array_shift(explode('_', $this->rendition->getSpecs())); ?> <?php echo $this->rendition->getWidth(), 'x', $this->rendition->getHeight(); ?></small></dd>
+    <dd><small><?php $specs = explode('_', $this->rendition->getSpecs()); echo array_shift($specs); ?> <?php echo $this->rendition->getWidth(), 'x', $this->rendition->getHeight(); ?></small></dd>
 </dl>
 <?php if (!$this->isDefault) { ?>
 <a href="<?php echo $this->url(array(

--- a/newscoop/application/modules/admin/views/scripts/slideshow-list.phtml
+++ b/newscoop/application/modules/admin/views/scripts/slideshow-list.phtml
@@ -29,6 +29,9 @@
 
 <script type="text/javascript">
 (function($) {
+    // don't cache slideshows list requests
+    $.ajaxSetup({ cache: false });
+
     /**
      * Slideshow model
      */

--- a/newscoop/library/Newscoop/Image/RenditionService.php
+++ b/newscoop/library/Newscoop/Image/RenditionService.php
@@ -283,7 +283,8 @@ class RenditionService
     {
         $options = array();
         foreach ($this->getRenditions() as $name => $rendition) {
-            $options[$name] = sprintf('%s (%s %dx%d)', $name, array_shift(explode('_', $rendition->getSpecs())), $rendition->getWidth(), $rendition->getHeight());
+            $specs = explode('_', $rendition->getSpecs());
+            $options[$name] = sprintf('%s (%s %dx%d)', $name, array_shift($specs), $rendition->getWidth(), $rendition->getHeight());
         }
 
         return $options;

--- a/newscoop/library/Newscoop/Package/PackageService.php
+++ b/newscoop/library/Newscoop/Package/PackageService.php
@@ -124,6 +124,14 @@ class PackageService
         $this->orm->persist($packageItem);
         $this->orm->flush();
 
+        $this->orm->refresh($package);
+        $offset = 0;
+        foreach ($package->getItems() as $item) {
+            $item->setOffset($offset);
+            $offset++;
+        }
+        $this->orm->flush();
+
         return $packageItem;
     }
 


### PR DESCRIPTION
- fix some php strict errors 
- prevent api caching on slideshows listing view (after removing slideshows, removed one was still visible on page)
- make sure that offset is always set when adding new items 
